### PR TITLE
feat: create parser for zksync info

### DIFF
--- a/content/_zksync.json
+++ b/content/_zksync.json
@@ -1,0 +1,18 @@
+{
+  "mainnet": {
+    "name": "zkSync Era Mainnet",
+    "rpc_url": "https://mainnet.era.zksync.io",
+    "websocket_url": "wss://mainnet.era.zksync.io/ws",
+    "chain_id": 324,
+    "currency_symbol": "ETH",
+    "block_explorer_url": "https://explorer.zksync.io/"
+  },
+  "testnet": {
+    "name": "zkSync Era Testnet",
+    "rpc_url": "https://testnet.era.zksync.dev",
+    "websocket_url": "wss://testnet.era.zksync.dev/ws",
+    "chain_id": 280,
+    "currency_symbol": "ETH",
+    "block_explorer_url": "https://sepolia.explorer.zksync.io/"
+  }
+}

--- a/server/plugins/parse-zk-tags.ts
+++ b/server/plugins/parse-zk-tags.ts
@@ -1,0 +1,29 @@
+import zkSyncConfig from '../../content/_zksync.json';
+
+const tags: { [key: string]: string } = {};
+
+export default defineNitroPlugin((nitroApp) => {
+  parseConfig(zkSyncConfig, 'zk');
+
+  nitroApp.hooks.hook('content:file:beforeParse', (file: { _id: string; body: string }) => {
+    if (file._id.endsWith('.md')) {
+      Object.keys(tags).forEach((key) => {
+        file.body = file.body.replace(new RegExp(`%%${key}%%`, 'g'), tags[key]);
+      });
+    }
+  });
+});
+
+function parseConfig(config: any, prefix: string) {
+  Object.keys(config).forEach((key) => {
+    const value = config[key];
+    const newPrefix = `${prefix}_${key}`;
+    if (typeof value === 'object' && value !== null) {
+      parseConfig(value, newPrefix);
+    } else {
+      tags[newPrefix] = value;
+    }
+  });
+
+  return tags;
+}


### PR DESCRIPTION
# What :computer: 
* Create a parser that replaces tags in markdown content with values defined in a _zksync.json file.

# Why :hand:
* For very important content, we don't want to copy/past and rewrite things all over the docs.

# How it works

Content is structured in a json file under `content/_zksync.json`. Tags are wrapped in `%%` and are prefixed with `zk_`. The path to the value in the json file is represented with underscores instead of a dot.

Let's say we want to put the Mainnet block explorer URL into a page somewhere. It's in the JSON file as `mainnet.block_explorer_url`. The tag for it will be `%%zk_mainnet_block_explorer_url%%`.
