### PR TITLE
feat: add check on zk parser

### DIFF
--- a/server/plugins/parse-zk-tags.ts
+++ b/server/plugins/parse-zk-tags.ts
@@ -12,6 +12,16 @@ export default defineNitroPlugin((nitroApp) => {
       });
     }
   });
+
+  nitroApp.hooks.hook('content:file:afterParse', (file) => {
+    if (file._id.endsWith('.md')) {
+      const regex = /%%/gm;
+      const body = JSON.stringify(file.body);
+      if (process.env.NODE_ENV !== 'production' && regex.test(body)) {
+        console.error(`Unparsed %% zk_tag found in ${file._file}`);
+      }
+    }
+  });
 });
 
 function parseConfig(config: any, prefix: string) {


### PR DESCRIPTION
# What :computer: 
* Add a console error if a zk tag is unparsed because of bad formatting

# Why :hand:
* Avoid displaying any unformatted/broken tags in production

# Evidence :camera:
![Screenshot 2024-04-23 at 3 46 14 PM](https://github.com/matter-labs/zksync-docs/assets/812331/48e35a1c-470d-43d9-9bbc-4d8c15efed65)

# NOTE
This does not stop a build process from happening. The parser runs on dev and if an error is Thrown it causes all sorts of hiccups on the local server to restart smoothly. For now this is just a console log for the developer to notice. May sit on this and think of a way to throw an error only on build later on.