### PR TITLE
feat: Link directly to doc semantic framework

### DIFF
--- a/content/00.build/90.contributing-to-documentation/30.documentation-styleguide.md
+++ b/content/00.build/90.contributing-to-documentation/30.documentation-styleguide.md
@@ -36,7 +36,7 @@ To minimize confusion due to global date format variations, adhere to the follow
 
 ## Kinds of zkSync Documentation
 
-Following the Diataxis framework, zkSync Docs categorizes content into:
+Following the [Diataxis](https://diataxis.fr/) framework, zkSync Docs categorizes content into:
 
 - **Tutorials**: Step-by-step instructions to teach general skills (e.g., Deploying your first contract on zkSync Era).
 - **Guides**: Task completion instructions for readers with basic knowledge (e.g., Debugging with zksync-cli).
@@ -46,7 +46,7 @@ Following the Diataxis framework, zkSync Docs categorizes content into:
 
 ### Choosing a category for writing
 
-Leverage the Diataxis system when crafting a new article for zkSync Docs.
+Leverage the [Diataxis](https://diataxis.fr/) system when crafting a new article for zkSync Docs.
 Writing without a clear category often results in unfocused content.
 A well-defined focus keeps the content streamlined and clarifies the takeaway for the reader.
 


### PR DESCRIPTION
This was unclear if not already familiar with the framework and avoids conflating this with eastern orthodoxy liturgy

# What :computer: 
* Replace the text Diataxis with a link to the diataxis page in the header section
* Replace the text Diataxis with a link to the diataxis page in the category section

# Why :hand:
* I hadn't heard of this framework before
*Searching for this text brings up some conflicting results depending on what site you trust

# Evidence :camera:

From here: https://zksync-docs-staging-5eb09--pr37-cbe-devrl-527-link-t-lxa3l56t.web.app/build/contributing-to-documentation/documentation-styleguide

![image](https://github.com/matter-labs/zksync-docs/assets/2054226/cbe538db-50fc-4dd1-9dd1-8c6c2ade04c9)
