### PR TITLE
fix: sidebar links

### DIFF
--- a/components/layout/Toc.vue
+++ b/components/layout/Toc.vue
@@ -12,13 +12,13 @@ const links = computed(() =>
     toc?.bottom?.edit && {
       icon: 'i-heroicons-pencil-square',
       label: 'Edit this page',
-      to: `${toc.bottom.edit}/${props.page?.value?._file}`,
+      to: `${toc.bottom.edit}/${props.page?._file}`,
       target: '_blank',
     },
     toc?.bottom?.feedback && {
       icon: 'i-heroicons-chat-bubble-oval-left-ellipsis',
       label: 'Share feedback',
-      to: `${toc.bottom.feedback}&title=Feedback for ${props.page?.value?.title}&body=Page: ${props.page?.value?._path}`,
+      to: `${toc.bottom.feedback}&title=Feedback for ${props.page?.title}&body=Page: ${props.page?._path}`,
       target: '_blank',
     },
     ...(toc?.bottom?.links || []),


### PR DESCRIPTION
# What :computer: 
* Links for "Edit this page" and "Share feedback" in the sidebar under the TOC were broken

# Why :hand:
* reference vue props were incorrect

