### PR TITLE
fix: updated verify commands

### DIFF
--- a/content/00.build/10.zksync-101/_upgrading/_uups/_hardhat_uups_contract_upgradability.md
+++ b/content/00.build/10.zksync-101/_upgrading/_uups/_hardhat_uups_contract_upgradability.md
@@ -370,7 +370,7 @@ With that execute the following command:
 ::code-group
 
 ```bash [npm]
-npm run hardhat verify <PROXY-ADDRESS>
+npx hardhat verify <PROXY-ADDRESS>
 ```
 
 ```bash [yarn]
@@ -378,7 +378,7 @@ yarn hardhat verify <PROXY-ADDRESS>
 ```
 
 ```bash [pnpm]
-pnpm run hardhat verify <PROXY-ADDRESS>
+pnpx exec hardhat verify <PROXY-ADDRESS>
 ```
 
 ```bash [bun]


### PR DESCRIPTION
# What :computer: 
* updated verify commands for npm and pnpm (UUPS) to align with Beacon and Transparent proxy tutorials - current `npm run hardhat verify <PROXY-ADDRESS>` fails

# Why :hand:
* Reason why first thing was added to PR
* Reason why second thing was added to PR
* Reason why third thing was added to PR

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended
<img width="937" alt="image" src="https://github.com/matter-labs/zksync-docs/assets/112873874/5c7b917a-d117-42c5-913a-f35f6c2702f0">


<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
