### PR TITLE
docs: rename generalPaymaster contract to gaslessPaymaster

### DIFF
--- a/content/00.build/10.zksync-101/50.paymaster.md
+++ b/content/00.build/10.zksync-101/50.paymaster.md
@@ -76,7 +76,7 @@ items: [{
 ## Takeaways
 
 - **Comprehensive Understanding of Paymaster Contracts:** This guide has provided a detailed look at both the
-`ApprovalFlowPaymaster` and the `GeneralPaymaster` contracts, illustrating how they manage transaction fees
+`ApprovalFlowPaymaster` and the `GaslessPaymaster` contracts, illustrating how they manage transaction fees
 in zkSync. These paymasters are pivotal in handling gas payments, offering a more accessible transaction
 experience for users.
 - **Flexibility and User Empowerment:** By covering the transaction fees through ERC20 tokens or general subsidies, these

--- a/content/00.build/10.zksync-101/_paymasters/_general_paymaster_flow.md
+++ b/content/00.build/10.zksync-101/_paymasters/_general_paymaster_flow.md
@@ -16,14 +16,14 @@ cd contract-paymaster-quickstart
 
 ---
 
-## Understanding the `GeneralPaymaster` contract
+## Understanding the `GaslessPaymaster` contract
 
-Let's start by reviewing the [`GeneralPaymaster.sol`](https://github.com/matter-labs/zksync-contract-templates/blob/main/templates/quickstart/hardhat/paymaster/contracts/GaslessPaymaster.sol)
+Let's start by reviewing the [`GaslessPaymaster.sol`](https://github.com/matter-labs/zksync-contract-templates/blob/main/templates/quickstart/hardhat/paymaster/contracts/GaslessPaymaster.sol)
 contract in the `contracts/` directory:
 
 ::drop-panel
-  ::panel{label="GeneralPaymaster.sol"}
-    ```solidity [GeneralPaymaster.sol]
+  ::panel{label="GaslessPaymaster.sol"}
+    ```solidity [GaslessPaymaster.sol]
     // SPDX-License-Identifier: MIT
     pragma solidity ^0.8.0;
 
@@ -121,7 +121,7 @@ exclusively callable by the system's bootloader, adding an extra layer of securi
 
 ---
 
-## Compile and deploy the `GeneralPaymaster` contract
+## Compile and deploy the `GaslessPaymaster` contract
 
 :display-partial{path = "/_partials/_compile-solidity-contracts"}
 
@@ -230,9 +230,9 @@ Paymaster ETH balance is now 5000000000000000
 
 ---
 
-## Interact with the GeneralPaymaster contract
+## Interact with the GaslessPaymaster contract
 
-This section will navigate you through the steps to interact with the `GeneralPaymaster` contract,
+This section will navigate you through the steps to interact with the `GaslessPaymaster` contract,
 using it to cover transaction fees for your operation.
 
 The interaction script is situated in the `/deploy/interact/` directory, named [`interactWithGaslessPaymaster.ts`](https://github.com/matter-labs/zksync-contract-templates/blob/main/templates/quickstart/hardhat/paymaster/deploy/interact/interactWithGaslessPaymaster.ts).


### PR DESCRIPTION
# Description

Change references from GeneralPaymaster to GaslessPaymaster for zkSync 101 Paymaster guide.

## Linked Issues

Resolves [DEVRL-617](https://linear.app/matterlabs/issue/DEVRL-617/[paymaster-general]-different-naming-of-the-paymaster-contract-on-cli)