### PR TITLE
fix: move particles on landing page behind content on page

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -28,6 +28,7 @@ defineOgImage({
         <vue-particles
           id="tsparticles"
           url="particles.json"
+          style="z-index: -10"
         />
       </ClientOnly>
       <template #headline>


### PR DESCRIPTION
<!--

Thank you for contributing to the ZKsync Docs!

Before submitting the PR, please make sure you do the following:

- Update your PR title to follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- Read the [Contributing Guide](https://github.com/matter-labs/zksync-docs/blob/main/CONTRIBUTING.md).
- Understand our [Code of Conduct](https://github.com/matter-labs/zksync-docs/blob/main/CODE_OF_CONDUCT.md)
- Please delete any unused parts of the template when submitting your PR

-->

# Description

Move the particles animation (on the landing page) to behind the content displayed

## Linked Issues

<!-- If you have any issues this PR is related to, link them here. -->
<!--
Check out https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
on how to automate linking a GitHub Issue to a PR.
-->

## Additional context

![image](https://github.com/matter-labs/zksync-docs/assets/1890113/cecd6d10-4df2-4d46-8ed3-11a6599f254a)

