### PR TITLE
fix(build,api-reference): fix errors in RPC API

### DIFF
--- a/content/00.build/70.api-reference/20.zks-rpc.md
+++ b/content/00.build/70.api-reference/20.zks-rpc.md
@@ -309,6 +309,42 @@ curl --request POST \
 
 ---
 
+## `zks_getBaseTokenL1Address`
+
+Retrieves the L1 base token address.
+
+#### Parameters
+
+None
+
+#### Returns
+
+**DATA, 20 bytes** - Layer 1 Ethereum address of base token.
+
+#### Example Request
+
+```sh
+curl --request POST \
+  --url https://mainnet.era.zksync.io/ \
+  --header 'Content-Type: application/json' \
+  --data '{
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "zks_getBaseTokenL1Address",
+      "params": []
+    }'
+```
+
+#### Example Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": "0x0000000000000000000000000000000000000001",
+  "id": 1
+}
+```
+
 ## `zks_getConfirmedTokens`
 
 Lists confirmed tokens. **Confirmed** in the method name means any token bridged to ZKsync Era via the official bridge.
@@ -1203,7 +1239,7 @@ curl --request POST \
 }
 ```
 
-### `zks_sendRawTransactionWithDetailedOutput`
+## `zks_sendRawTransactionWithDetailedOutput`
 
 Executes a transaction and returns its hash, storage logs, and events that would have been generated
 if the transaction had already been included in the block. The API has a similar behaviour to
@@ -1225,7 +1261,7 @@ relationships between each other.
 
 ```sh
 curl -X POST -H "Content-Type: application/json" \
---data '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["Signed Transaction"],"id":1}' \
+--data '{"jsonrpc":"2.0","method":"zks_sendRawTransactionWithDetailedOutput","params":["Signed Transaction"],"id":1}' \
 "https://mainnet.era.zksync.io"
 ```
 

--- a/content/00.build/70.api-reference/35.ethereum-rpc.md
+++ b/content/00.build/70.api-reference/35.ethereum-rpc.md
@@ -412,6 +412,7 @@ curl --request POST \
       "transactionHash": "0xfdfcfdc6a0e2e3d09218749a752a2c2933f9eda5e9985c7fa3d861cb0112817d",
       "transactionIndex": "0x0",
       "logIndex": "0x0",
+      "l1BatchNumber": null,
       "transactionLogIndex": "0x0",
       "logType": null,
       "removed": false


### PR DESCRIPTION
# Description

Fix the errors in JSON RPC API for `zks` and `eth` namespaces.