### PR TITLE
fix: docs

### DIFF
--- a/content/00.build/40.tooling/30.foundry/20.getting-started.md
+++ b/content/00.build/40.tooling/30.foundry/20.getting-started.md
@@ -118,7 +118,7 @@ The compiled files are stored in a structured directory at `<PROJECT-ROOT>/zkout
 **Usage:**
 
 ```sh
-forge build [OPTIONS] --zksync
+forge build [OPTIONS] --zksync -- use solc:<VERSION>
 ```
 
 **Key Compiler Options:**

--- a/content/00.build/60.test-and-debug/20.in-memory-node.md
+++ b/content/00.build/60.test-and-debug/20.in-memory-node.md
@@ -19,7 +19,7 @@ In fork mode, it retrieves missing storage data from a remote source when not av
 Moreover it also uses the remote server (openchain) to resolve the ABI and topics to human readable names.
 
 You can visit the `era-test-node` repository [to learn more](%%zk_git_repo_era-test-node%%).
-
+In addition you may check `In-Memory node` vs `Dockerized local setup` [here](/build/test-and-debug#in-memory-node-vs-dockerized-local-setup).
 ## Run actions with `zksync-cli`
 
 You can setup the In-Memory Node quickly with `zksync-cli dev start`.


### PR DESCRIPTION
todo:
- [Install and set up era_test_node](https://zksync-docs-staging-5eb09--pr157-anastasiia-fixes-rpys7467.web.app/build/test-and-debug/in-memory-node#install-and-set-up-era_test_node) section is outdated - so has to be updated.
- mention about https://github.com/matter-labs/era-test-node/blob/main/SUPPORTED_APIS.md in docs