### PR TITLE
fix: removes solc version

### DIFF
--- a/content/00.build/10.zksync-101/_deploy_factory/_foundry_deploy_contract_factory.md
+++ b/content/00.build/10.zksync-101/_deploy_factory/_foundry_deploy_contract_factory.md
@@ -76,7 +76,7 @@ For this particular guide we are making use of `zksolc`.
 To compile the contracts in the project, run the following command:
 
 ```bash
-forge build --zksync --use 0.8.20
+forge build --zksync
 ```
 
 Upon successful compilation, you'll receive output detailing the

--- a/content/00.build/10.zksync-101/_hello-zksync/_foundry_deploy_contract.md
+++ b/content/00.build/10.zksync-101/_hello-zksync/_foundry_deploy_contract.md
@@ -90,7 +90,7 @@ For this particular guide we are making use of `zksolc`.
 To compile the contracts in the project, run the following command:
 
 ```bash
-forge build --zksync --use=0.8.24
+forge build --zksync
 ```
 
 Upon successful compilation, you'll receive output detailing the

--- a/content/00.build/10.zksync-101/_testing/_foundry_contract_testing.md
+++ b/content/00.build/10.zksync-101/_testing/_foundry_contract_testing.md
@@ -91,7 +91,7 @@ For this particular guide we are making use of `zksolc`.
 To compile the contracts in the project, run the following command:
 
 ```bash
-forge build --zksync --use 0.8.20
+forge build --zksync
 ```
 
 Upon successful compilation, you'll receive output detailing the


### PR DESCRIPTION
# Description

Removes hardcoded solc version in Foundry tutorials

## Linked Issues

N/A

## Additional context
