### PR TITLE
fix: mispelling on zk chains page

### DIFF
--- a/content/10.zk-stack/05.concepts/50.zk-chains.md
+++ b/content/10.zk-stack/05.concepts/50.zk-chains.md
@@ -152,7 +152,7 @@ This method is straightforward but has limitations:
 ### L3s: Layered proof aggregation
 
 In this model, ZK chains can act as Layer 3 (L3) networks that settle their proofs onto an intermediary Layer 2 (L2) ZK chain.
- hThis structure allows for several benefits and drawbacks:
+This structure allows for several benefits and drawbacks:
 
 - **Faster Inter-L3 Messaging**: L3s on the same L2 can communicate more swiftly and cheaply.
 - **Atomic Transactions**: Transactions across L3s can be made atomic through the L2, enhancing transaction reliability.


### PR DESCRIPTION
# Description

Fix a mispelling on the ZK Chains page.