### PR TITLE
fix(web3js): link

### DIFF
--- a/content/00.build/00.index.md
+++ b/content/00.build/00.index.md
@@ -67,7 +67,7 @@ zkvyper](/zk-stack/components/compiler/toolchain)**.
 :check-icon Use existing frameworks
 like [Hardhat](/build/tooling/hardhat/getting-started), libraries like
 [Ethers](https://docs.ethers.org/v6/), [Viem](https://viem.sh/zksync), or
-[web3.js](https://web3js.readthedocs.io/en/v1.5.2/index.html), and tools like [theGraph](https://thegraph.com/),
+[web3.js](https://docs.web3js.org/), and tools like [theGraph](https://thegraph.com/),
 [Thirdweb](https://thirdweb.com/zksync), or
 [Chainlink](https://docs.chain.link/data-feeds/price-feeds/addresses?network=zksync&page=1).
 


### PR DESCRIPTION
Link for Web3.js was outdated. Update it to current docs.
