### PR TITLE
chore: clarify usage of createAccount / create2Account for deploying

### DIFF
--- a/content/00.build/65.developer-reference/40.account-abstraction/40.building-smart-accounts.md
+++ b/content/00.build/65.developer-reference/40.account-abstraction/40.building-smart-accounts.md
@@ -22,10 +22,11 @@ This standard is endorsed by the ZKsync team and is integral to our signature-ve
 
 ### Deployment Process
 
-Deploying account logic follows a process similar to deploying a standard smart
-contract. However, to distinguish smart contracts that are not intended to be
-treated as accounts, use the `createAccount`/`create2Account` methods of the
-deployer system contract instead of `create`/`create2`.
+While deploying account logic is similar to deploying a standard smart contract,
+it’s important to differentiate contracts intended to function as accounts.
+For this purpose, use the `createAccount` or `create2Account` methods of the deployer
+system contract, rather than the general `create` or `create2` methods, which are
+used for contracts not intended to act as accounts.
 
 #### Example Using `zksync-ethers` SDK (v5)
 


### PR DESCRIPTION

# Description

- updated zksync-docs/content/00.build/65.developer-reference/40.account-abstraction/40.building-smart-accounts.md to be more clear about using `createAccount` and `create2Account` for deploying smart contract accounts. 