### PR TITLE
feat: Cookbook Onboard (AI Assistant & Playground) integration

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -21,6 +21,36 @@ useHead({
     { rel: 'icon', href: '/zksync-icon_150.svg', sizes: 'any', type: 'image/svg+xml' },
     { rel: 'apple-touch-icon', href: '/apple-touch-icon.png' },
   ],
+  script: [
+    {
+      children: `
+      (function() {
+        // Cookbook Onboard (AI Assistant). API key is public so it's fine to just hardcode it here.
+        var COOKBOOK_API_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NWNlNzUwZmZiMDBlZWUyNThjNmUxMjkiLCJpYXQiOjE3MDgwMjkxOTksImV4cCI6MjAyMzYwNTE5OX0.vrpJUZNG2jBFegOyENxgLJfStfyP7R1sQYE_I4XNo40";
+
+        document.addEventListener('DOMContentLoaded', function() {
+          var element = document.getElementById('__cookbook');
+          if (!element) {
+            element = document.createElement('div');
+            element.id = '__cookbook';
+            element.dataset.apiKey = COOKBOOK_API_KEY;
+            document.body.appendChild(element);
+          }
+
+          var script = document.getElementById('__cookbook-script');
+          if (!script) {
+            script = document.createElement('script');
+            script.src = 'https://cdn.jsdelivr.net/npm/@cookbookdev/docsbot/dist/standalone/index.cjs.js';
+            script.id = '__cookbook-script';
+            script.defer = true;
+            document.body.appendChild(script);
+          }
+        });
+      })();
+  `,
+      key: 'a',
+    },
+  ],
   htmlAttrs: {
     lang: 'en',
   },


### PR DESCRIPTION
## Preview
Preview link: https://docsbot-demo-git-zksync-cookbookdev.vercel.app/

## Ask Cookbook AI Assistant
Cookbook's Ask Cookbook AI assistant and co-pilot is trained on all existing ZKSync resources (source code, docs website, etc.) and is available as a standalone modal, embeddable as a button on any page (recommended for technical docs). It answers developer questions about building on ZKSync, acting as an enhanced and streamlined technical documentation search tool as well as a Solidity coding co-pilot.

Ask Cookbook AI can also access context from thousands of data sources indexed by Cookbook.dev in addition to ZKSync-specific data sources, providing the best blockchain developer-focused answers of any chatbot on the market. Cookbook will assist in the tuning and calibration of the AI assistant to ensure the highest answer quality.

![image](https://github.com/user-attachments/assets/b378ef45-07be-4a68-aa49-dedd9730ff95)
  

## Cookbook Onboard Playground
The Cookbook Onboard Playground embeds a Solidity IDE with smart contract templates displayed alongside the Ask Cookbook AI Assistant.

Developers can search for and deploy Cookbook’s entire smart contract library from your technical documentation.

Features:
- Deploy smart contracts or entire protocols to ZKSync Era without leaving the docs
- Acts as a free, no-code or low-code token and NFT launchpad
- Save source code as a Foundry, Hardhat, or Scaffold project or export it to Remix or Chain IDE in one click

![image](https://github.com/user-attachments/assets/91a6e7b7-71de-428d-bd47-54b6093ab2a4)