### PR TITLE
fix: link in _call-request-params.md

### DIFF
--- a/content/00.build/70.api-reference/_partials/_call-request-params.md
+++ b/content/00.build/70.api-reference/_partials/_call-request-params.md
@@ -17,5 +17,5 @@ title: CallRequest Params
 - **transaction_type**: QUANTITY, 8 bytes - Type of the transaction.
 - **access_list**: AccessList - EIP-2930 access list.
 - **customData**: OBJECT - Extra parameters for
-[EIP712 transactions](zk-stack/concepts/transaction-lifecycle#eip-712-0x71), like `paymasterParams` or `customSignature`.
+[EIP712 transactions](/zk-stack/concepts/transaction-lifecycle#eip-712-0x71), like `paymasterParams` or `customSignature`.
 ::


### PR DESCRIPTION
Fix broken link, nuxt linking requires a `/` at the beginning of the URL to indicate an absolute link. Otherwise it is treated as  a relative link.
