### PR TITLE
fix: resolve trailing slash

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,6 @@
 {
   "hosting": {
+    "trailingSlash": false,
     "public": ".output/public",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "headers": [

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -24,6 +24,13 @@ export default defineNuxtConfig({
     '/zk-stack/concepts': { redirect: '/zk-stack/concepts/transaction-lifecycle' },
     '/zk-stack/running-a-zk-chain': { redirect: '/zk-stack/running-a-zk-chain/locally' },
   },
+  experimental: {
+    defaults: {
+      nuxtLink: {
+        trailingSlash: 'remove',
+      },
+    },
+  },
   pwa: {
     selfDestroying: true,
     strategies: 'generateSW',


### PR DESCRIPTION

# Description

Explicitly define trailing slash settings for URLs. There seems to be a redirect happening somehow that will redirect a URL for example: "docs.zksync.io/build" -> "docs.zksync.io/build/" but then the trailing slash is removed without a redirect. There may be a clash between hosting configuration, nuxt configuration, and nuxt seo module configuration.

We want trailing slashes removed to be the default configuration for URLs and we do not want any redirects flipping between the two.