### PR TITLE
fix: use latest zksync-contracts version

### DIFF
--- a/content/00.build/65.developer-reference/30.ethereum-differences/60.contract-deployment.md
+++ b/content/00.build/65.developer-reference/30.ethereum-differences/60.contract-deployment.md
@@ -159,7 +159,7 @@ To have a deterministic address, you should use the `create2` method from
 
 Deploying contracts on ZKsync Era is also possible via L1-L2 communication.
 
-The [interface](https://github.com/matter-labs/era-contracts/blob/main/l1-contracts/contracts/zksync/interfaces/IZkSync.sol)
+The [interface](https://github.com/matter-labs/era-contracts/blob/main/l1-contracts/contracts/state-transition/chain-interfaces/IZkSyncHyperchain.sol)
 for submitting L1->L2 transactions accepts
 the list of all the factory dependencies required for this particular transaction.
 The logic for working with them is the same as for the default L2 deployments. The

--- a/content/00.build/65.developer-reference/80.l1-l2-interoperability.md
+++ b/content/00.build/65.developer-reference/80.l1-l2-interoperability.md
@@ -15,7 +15,7 @@ Many use cases require multi-layer interoperability, such as:
 ## L1 to L2 communication
 
 L1 to L2 communication is governed by the
-[`IZkSync.sol`](https://github.com/matter-labs/era-contracts/blob/main/l1-contracts/contracts/zksync/interfaces/IZkSync.sol) inherited interfaces.
+[`IZkSyncHyperchain.sol`](https://github.com/matter-labs/era-contracts/blob/main/l1-contracts/contracts/state-transition/chain-interfaces/IZkSyncHyperchain.sol) inherited interfaces.
 
 ### Gas estimation
 


### PR DESCRIPTION


# Description

Apply changes from the latest zksync-contracts version.

**DO NOT MERGE UNTIL latest zksync-contracts is published as latest!**
