### PR TITLE
fix: Description of the deployment process on Ethereum

### DIFF
--- a/content/00.build/65.developer-reference/30.ethereum-differences/60.contract-deployment.md
+++ b/content/00.build/65.developer-reference/30.ethereum-differences/60.contract-deployment.md
@@ -22,7 +22,9 @@ through EIP712 transactions, with the `factory_deps` field containing the byteco
 
 **How deploying contracts works on Ethereum.**
 
-To deploy a contract on Ethereum, a user sends a transaction with the empty `to` field and with the `data` field of the transaction equal to the contract creation bytecode concatenated with the constructor parameters.
+To deploy a contract on Ethereum, a user sends a transaction with the empty `to` field
+and with the `data` field of the transaction equal to the contract creation bytecode
+concatenated with the constructor parameters.
 
 **How deploying contracts works on ZKsync.**
 

--- a/content/00.build/65.developer-reference/30.ethereum-differences/60.contract-deployment.md
+++ b/content/00.build/65.developer-reference/30.ethereum-differences/60.contract-deployment.md
@@ -22,9 +22,7 @@ through EIP712 transactions, with the `factory_deps` field containing the byteco
 
 **How deploying contracts works on Ethereum.**
 
-To deploy a contract on Ethereum, a user sends a transaction to the zero address
-(`0x000...000`) with the `data` field of the transaction equal to the contract
-bytecode concatenated with the constructor parameters.
+To deploy a contract on Ethereum, a user sends a transaction with the empty `to` field and with the `data` field of the transaction equal to the contract creation bytecode concatenated with the constructor parameters.
 
 **How deploying contracts works on ZKsync.**
 


### PR DESCRIPTION
Hey 👋 

I'm changing the description of the deployment process on Ethereum. To verify my claims run:

```shell
cast tx 0x21dfeea6c82d47203f91aba30af5e5ef3d623aa8206596fbd8c466a5b1586f02 --json | jq .to
```

Or choose any other deployment tx.