### PR TITLE
fix: fix wording for returndatacopy behavior

### DIFF
--- a/content/00.build/65.developer-reference/30.ethereum-differences/10.evm-instructions.md
+++ b/content/00.build/65.developer-reference/30.ethereum-differences/10.evm-instructions.md
@@ -83,9 +83,12 @@ deployed to the same the Ethereum-matching addresses on ZKsync.
 
 For calls, you specify a memory slice to write the return data to, e.g. `out` and `outsize` arguments for
 `call(g, a, v, in, insize, out, outsize)`. In EVM, if `outsize != 0`, the allocated memory will grow to `out + outsize`
-(rounded up to the words) regardless of the `returndatasize`. On ZKsync Era, `returndatacopy`, similar to `calldatacopy`,
-is implemented as a cycle iterating over return data with a few additional checks and triggering a panic if
-`out + outsize > returndatasize` to simulate the same behavior as in EVM.
+(rounded up to the words) regardless of the `returndatasize`.
+
+On ZKsync Era, `returndatacopy`, similar to `calldatacopy`, is implemented as a cycle iterating over return data with a
+few additional checks: a call `returndatacopy(destOffset, offset, size)` will trigger a panic if
+`offset + size > returndatasize` to simulate the same behavior as in EVM. See
+[EIP-211](https://eips.ethereum.org/EIPS/eip-211) for more details.
 
 Thus, unlike EVM where memory growth occurs before the call itself, on ZKsync Era, the necessary copying of return data
 happens only after the call has ended, leading to a difference in `msize()` and sometimes ZKsync Era not panicking where


### PR DESCRIPTION
The previous wording was ambiguous, the new one is more explicit.