### PR TITLE
docs: add docs for zk_toolbox

### DIFF
--- a/content/00.build/25.zk-toolbox/00.index.md
+++ b/content/00.build/25.zk-toolbox/00.index.md
@@ -1,0 +1,59 @@
+---
+title: Getting Started
+description: Learn how to use the awesome zk_toolbox CLI toolkit for creating and managing ZK Stack Chains.
+---
+
+## Overview
+ZK Toolbox is a comprehensive toolkit for creating and managing ZK Stack chains. It provides developers with a powerful set of utilities to streamline their workflow when working with ZKSync. With ZK Toolbox, you can effortlessly set up ecosystems, manage chains, handle prover operations, and integrate essential services like observability tools and explorers. You can also efficiently develop, test, and maintain ZKsync.
+
+The ZK Toolbox consists of two main components:
+
+- **ZK Inception:** A tool for creating and managing ZK Stacks, which are the foundational elements of ZKSync networks.
+- **ZK Supervisor:** A collection of utilities for developing and maintaining ZKSync infrastructure.
+
+::card-group
+  ::card
+  ---
+  title: ZK Inspection
+  icon: i-heroicons-rocket-launch-solid
+  to: /build/start-coding/quick-start
+  ---
+  Learn how to use zk_toolbox to create and manage ZK Stack chains.
+  ::
+  ::card
+  ---
+  title: ZK Supervisor
+  icon: i-heroicons-command-line-solid
+  to: /build/start-coding/zksync-101
+  ---
+  See zk_toolbox commands for developing with ZKSync.
+  ::
+::
+
+### Who Should Use ZK Toolbox?
+ZK Toolbox is designed for:
+
+- **Blockchain Developers and Infrastructure Engineers:** Those who want to build and deploy applications on ZKSync, as well as set up and maintain ZKSync infrastructure.
+- **Network Operators:** Managing ZKSync networks or running external nodes.
+
+### ZK Toolbox vs ZKSync CLI
+
+While ZKSync CLI is used for scaffolding, deploying, and managing smart contracts on ZKSync, ZK Toolbox creates and manages ZK Stack ecosystems.
+
+## Installation
+
+To install ZK Inception and ZK Supervisor, you have two options:
+
+1. Install from Git:
+
+```bash
+cargo install --git https://github.com/matter-labs/zksync-era/ --locked zk_inception zk_supervisor --force
+```
+
+2. Build manually from a local copy of the [ZKsync repository](https://github.com/matter-labs/zksync-era/):
+
+```bash
+./bin/zkt
+```
+
+After completing the installation, you can go ahead and use [ZK Inspection](/build/zk-toolbox/zk-inspection) and [ZK Supervisor](/build/zk-toolbox/zk-supervisor) commands.

--- a/content/00.build/25.zk-toolbox/00.index.md
+++ b/content/00.build/25.zk-toolbox/00.index.md
@@ -14,7 +14,7 @@ The ZK Toolbox consists of two main components:
 ::card-group
   ::card
   ---
-  title: ZK Inspection
+  title: ZK Inception
   icon: i-heroicons-rocket-launch-solid
   to: /build/start-coding/quick-start
   ---
@@ -56,4 +56,4 @@ cargo install --git https://github.com/matter-labs/zksync-era/ --locked zk_incep
 ./bin/zkt
 ```
 
-After completing the installation, you can go ahead and use [ZK Inspection](/build/zk-toolbox/zk-inspection) and [ZK Supervisor](/build/zk-toolbox/zk-supervisor) commands.
+After completing the installation, you can go ahead and use [ZK Inception](/build/zk-toolbox/zk-inception) and [ZK Supervisor](/build/zk-toolbox/zk-supervisor) commands.

--- a/content/00.build/25.zk-toolbox/10.zk-inception.md
+++ b/content/00.build/25.zk-toolbox/10.zk-inception.md
@@ -1,6 +1,6 @@
 ---
-title: ZK Inspection
-description: Create and manage ZK Stack with ZK Inspection
+title: ZK Inception
+description: Create and manage ZK Stack with ZK Inception
 ---
 
 ZK Inception is a tool that facilitates the creation and management of ZK Stacks. It provides a set of interactive commands that can also accept arguments via the command line.

--- a/content/00.build/25.zk-toolbox/10.zk-inspection.md
+++ b/content/00.build/25.zk-toolbox/10.zk-inspection.md
@@ -1,0 +1,200 @@
+---
+title: ZK Inspection
+description: Create and manage ZK Stack with ZK Inspection
+---
+
+ZK Inception is a tool that facilitates the creation and management of ZK Stacks. It provides a set of interactive commands that can also accept arguments via the command line.
+
+### Prerequisites
+
+Before using ZK Inception, ensure you have set up the necessary dependencies on your machine. Follow the [setup instructions](https://github.com/matter-labs/zksync-era/blob/main/docs/guides/setup-dev.md), but you can skip the Environment section for now.
+
+### Foundry Integration
+
+ZK Inception uses Foundry for deploying smart contracts. You can pass Foundry integration flags using the `-a` option. For example:
+
+```bash
+zk_inception -a --gas-estimate-multiplier=500
+```
+
+
+### Ecosystem Management
+
+ZK Stack allows you to create a new ecosystem or connect to an existing one. An ecosystem includes components like the BridgeHub, shared bridges, and state transition managers.
+
+#### Creating an Ecosystem
+
+To create a ZK Stack project, start by creating an ecosystem:
+
+```bash
+zk_inception ecosystem create
+```
+
+#### Initializing an Ecosystem
+
+If the ecosystem has never been deployed before, initialize it:
+
+```bash
+zk_inception ecosystem init
+```
+
+For default parameters, use:
+
+```bash
+zk_inception ecosystem init --dev
+```
+
+#### Changing the Default Chain
+
+To change the default ZK chain:
+
+```bash
+zk_inception ecosystem change-default-chain
+```
+
+#### Setting Up Observability
+
+To set up [era-observability](https://github.com/matter-labs/era-observability):
+
+```bash
+zk_inception ecosystem setup-observability
+```
+
+
+### ZK Chain Management
+
+#### Creating a New Chain
+
+Create additional chains and switch between them:
+
+```bash
+zk_inception chain create
+```
+
+#### Initializing a Chain
+
+Deploy contracts and initialize a ZK Chain:
+
+```bash
+zk_inception chain init
+```
+
+### Running the ZK Server
+
+To run the chain:
+
+```bash
+zk_inception server
+```
+
+### Prover Management
+
+#### Initializing the Prover
+
+To initialize the prover and prepare it for generating proofs:
+
+```bash
+zk_inception prover init
+```
+
+#### Generating Setup Keys
+
+Generate the setup keys necessary for proving operations:
+
+```bash
+zk_inception prover generate-sk
+```
+
+#### Running the Prover
+
+Start the prover to begin generating proofs for the network:
+
+```bash
+zk_inception prover run
+```
+
+### Contract Verifier
+
+#### Initializing the Contract Verifier
+
+Initialize the contract verifier to start verifying proofs:
+
+```bash
+zk_inception contract-verifier init
+```
+
+#### Running the Contract Verifier
+
+Run the contract verifier to validate proofs and ensure contract correctness:
+
+```bash
+zk_inception contract-verifier run
+```
+
+### External Node Management
+
+#### Preparing Configs
+
+Generate and prepare the necessary configurations for the external node:
+
+```bash
+zk_inception en configs
+```
+
+#### Initializing the External Node
+
+Initialize the external node before starting it on the network:
+
+```bash
+zk_inception en init
+```
+
+#### Running the External Node
+
+Run the external node to participate in the network:
+
+```bash
+zk_inception en run
+```
+
+### Portal and Explorer
+
+#### Running the Portal
+
+Run the portal to interact with the ZKsync network:
+
+```bash
+zk_inception portal
+```
+
+#### Initializing the Explorer
+
+Initialize the explorer to monitor and track network activity:
+
+```bash
+zk_inception explorer init
+```
+
+#### Running the Explorer Backend
+
+Start the backend service of the explorer for a specific chain:
+
+```bash
+zk_inception explorer backend --chain <chain_name>
+```
+
+#### Running the Explorer Frontend
+
+Run the frontend service of the explorer to provide a user interface:
+
+```bash
+zk_inception explorer run
+```
+
+### Updating the Node
+
+To update your node with the latest changes:
+
+```bash
+zk_inception update
+```

--- a/content/00.build/25.zk-toolbox/20.zk-supervisor.md
+++ b/content/00.build/25.zk-toolbox/20.zk-supervisor.md
@@ -1,0 +1,65 @@
+---
+title: ZK Supervisor
+description: Managing ZK Stack with ZK Supervisor
+---
+
+ZK Supervisor provides an array of utilities for managing the ZK Stack, including database management, cleaning up artifacts, running tests, and building contracts. Essentially, it simplifies key development tasks.
+
+## ZK Supervisor Tools
+
+### Database Management
+
+Manage the database for your ZKSync environment:
+
+```bash
+zk_supervisor db
+```
+
+### Cleaning Artifacts
+
+Use this command to clean up outdated or unnecessary build artifacts:
+
+```bash
+zk_supervisor clean
+```
+
+### Running Tests
+
+To run the full suite of unit and integration tests for your ZKsync codebase:
+
+```bash
+zk_supervisor test
+```
+
+### Creating Snapshots
+
+This command allows you to create snapshots of the system’s state, useful for rollbacks and auditing:
+
+```bash
+zks snapshot create
+```
+
+### Building Contracts
+
+Compile and build all the smart contracts in your ZKsync project:
+
+```bash
+zks contracts
+```
+
+### Formatting Code
+
+Automatically format your code to meet the project’s coding standards:
+
+```bash
+zks fmt
+```
+
+### Linting Code
+
+Run linting tools to analyze your code and ensure that it adheres to syntax and style guidelines:
+
+```bash
+zks lint
+```
+

--- a/content/00.build/25.zk-toolbox/_dir.yaml
+++ b/content/00.build/25.zk-toolbox/_dir.yaml
@@ -1,0 +1,1 @@
+title: ZK Toolbox


### PR DESCRIPTION

# Description

This PR adds the documentation for [zk_toolbox](https://github.com/matter-labs/zksync-era/tree/57b99d4fc906ae7ab5532ea23a069b34a2ee7c02/zk_toolbox) to the ZKSync docs website. It includes 3 pages:

1. Getting Started:
    - Overview information
    - Who should use zk_toolbox
    -  ZK Toolbox vs ZKSync CLI
    - Installation Guide
2. ZK Inception
    - Prerequisites
    - Foundry Integration
    - CLI Commands
4. ZK Supervisor
    - CLI Commands


It has the following folder structure:

```
 . . .
 ┣ 📂25.zk-toolbox
 ┃ ┣ 📜00.index.md
 ┃ ┣ 📜10.zk-inspection.md
 ┃ ┣ 📜20.zk-supervisor.md
 ┃ ┗ 📜_dir.yaml
 . . .
 ```
 

## Linked Issues

This PR resolves https://github.com/matter-labs/zksync-docs/issues/228 
