### PR TITLE
feat: add step removing conflicting hardhat plugins

### DIFF
--- a/content/00.build/40.tooling/20.hardhat/20.guides/20.migrating-to-zksync.md
+++ b/content/00.build/40.tooling/20.hardhat/20.guides/20.migrating-to-zksync.md
@@ -45,12 +45,16 @@ You can learn more about each plugin in the [Getting started section](/build/too
 
    - `@nomicfoundation/hardhat-ethers`: `@matterlabs/hardhat-zksync` includes `hardhat-ethers` extended with with support for ZKsync and non-ZKsync networks.
    - `@openzeppelin/hardhat-upgrades`:  `@matterlabs/hardhat-zksync` includes `hardhat-upgrades` extended with support for ZKsync and non-ZKsync networks.
-   - `@nomicfoundation/hardhat-toolbox`: this plugin includes `@nomicfoundation/hardhat-ethers` which can cause conflicts. Import necessary components separately excluding `@nomicfoundation/hardhat-ethers`.
-   ```js
+   - `@nomicfoundation/hardhat-toolbox`: this plugin includes `@nomicfoundation/hardhat-ethers` which can cause conflicts. Import necessary
+     components separately excluding `@nomicfoundation/hardhat-ethers`.
+
+   ```ts
    // import "@nomicfoundation/hardhat-toolbox"
    // import "@nomicfoundation/hardhat-ethers"
    // import "@openzeppelin/hardhat-upgrades"
    import "@matterlabs/hardhat-zksync"
+   ```
+
 4. Add the preferred ZKsync networks to the `hardhat.config.ts` file:
 
     ```js

--- a/content/00.build/40.tooling/20.hardhat/20.guides/20.migrating-to-zksync.md
+++ b/content/00.build/40.tooling/20.hardhat/20.guides/20.migrating-to-zksync.md
@@ -43,19 +43,9 @@ You can learn more about each plugin in the [Getting started section](/build/too
 
 3. Remove conflicting plugin imports
 
-    - `@nomicfoundation/hardhat-ethers`
-   
-        `@matterlabs/hardhat-zksync` includes hardhat-ethers extended with zksync funcionality.
-      
-    - `@nomicfoundation/hardhat-toolbox`
-  
-        `@nomicfoundation/hardhat-toolbox` includes conflicting `@nomicfoundation/hardhat-ethers`.
-        Import necessery components separately excluding `@nomicfoundation/hardhat-ethers`.
-      
-    - `@openzeppelin/hardhat-upgrades`
-      
-        `@matterlabs/hardhat-zksync` includes `@openzeppelin/hardhat-upgrades` wrapped for zksync compatibility.
-
+   - `@nomicfoundation/hardhat-ethers`: `@matterlabs/hardhat-zksync` includes `hardhat-ethers` extended with with support for ZKsync and non-ZKsync networks.
+   - `@openzeppelin/hardhat-upgrades`:  `@matterlabs/hardhat-zksync` includes `hardhat-upgrades` extended with support for ZKsync and non-ZKsync networks.
+   - `@nomicfoundation/hardhat-toolbox`: this plugin includes `@nomicfoundation/hardhat-ethers` which can cause conflicts. Import necessary components separately excluding `@nomicfoundation/hardhat-ethers`.
 4. Add the preferred ZKsync networks to the `hardhat.config.ts` file:
 
     ```js

--- a/content/00.build/40.tooling/20.hardhat/20.guides/20.migrating-to-zksync.md
+++ b/content/00.build/40.tooling/20.hardhat/20.guides/20.migrating-to-zksync.md
@@ -46,6 +46,11 @@ You can learn more about each plugin in the [Getting started section](/build/too
    - `@nomicfoundation/hardhat-ethers`: `@matterlabs/hardhat-zksync` includes `hardhat-ethers` extended with with support for ZKsync and non-ZKsync networks.
    - `@openzeppelin/hardhat-upgrades`:  `@matterlabs/hardhat-zksync` includes `hardhat-upgrades` extended with support for ZKsync and non-ZKsync networks.
    - `@nomicfoundation/hardhat-toolbox`: this plugin includes `@nomicfoundation/hardhat-ethers` which can cause conflicts. Import necessary components separately excluding `@nomicfoundation/hardhat-ethers`.
+   ```js
+   // import "@nomicfoundation/hardhat-toolbox"
+   // import "@nomicfoundation/hardhat-ethers"
+   // import "@openzeppelin/hardhat-upgrades"
+   import "@matterlabs/hardhat-zksync"
 4. Add the preferred ZKsync networks to the `hardhat.config.ts` file:
 
     ```js

--- a/content/00.build/40.tooling/20.hardhat/20.guides/20.migrating-to-zksync.md
+++ b/content/00.build/40.tooling/20.hardhat/20.guides/20.migrating-to-zksync.md
@@ -41,7 +41,22 @@ You can learn more about each plugin in the [Getting started section](/build/too
     import "@matterlabs/hardhat-zksync";
     ```
 
-3. Add the preferred ZKsync networks to the `hardhat.config.ts` file:
+3. Remove conflicting plugin imports
+
+    - `@nomicfoundation/hardhat-ethers`
+   
+        `@matterlabs/hardhat-zksync` includes hardhat-ethers extended with zksync funcionality.
+      
+    - `@nomicfoundation/hardhat-toolbox`
+  
+        `@nomicfoundation/hardhat-toolbox` includes conflicting `@nomicfoundation/hardhat-ethers`.
+        Import necessery components separately excluding `@nomicfoundation/hardhat-ethers`.
+      
+    - `@openzeppelin/hardhat-upgrades`
+      
+        `@matterlabs/hardhat-zksync` includes `@openzeppelin/hardhat-upgrades` wrapped for zksync compatibility.
+
+4. Add the preferred ZKsync networks to the `hardhat.config.ts` file:
 
     ```js
     networks: {


### PR DESCRIPTION
# Description

- add step to hardhat migration guide - "remove conflicting plugins"

## Additional context

- some builders forget to do this. Not doing this results in hard to understand error messages