### PR TITLE
docs: copy types into docs

### DIFF
--- a/content/00.build/30.zksync-sso/00.index.md
+++ b/content/00.build/30.zksync-sso/00.index.md
@@ -3,9 +3,12 @@ title: Intro
 description: Learn about ZKsync Smart Sign-on.
 ---
 
-ZKsync SSO is a smart wallet and sign-on designed for developers building on the ZKsync.
+ZKsync SSO is a smart wallet and sign-on designed for developers building on ZKsync.
 It simplifies user authentication, session management,
-and transaction processing by leveraging native ZKsync features like Account Abstraction (AA) and paymasters. <br><br>
+and transaction processing by leveraging native ZKsync features like
+[Account Abstraction](/build/developer-reference/account-abstraction) and
+[Paymasters](/build/developer-reference/account-abstraction/paymasters).
+
 This means you can integrate secure sign-on functionality into your applications without the need to develop complex wallet infrastructures
 or worry about compatibility with third-party wallets.
 Users logging in with ZKsync SSO on Era automatically access these advanced capabilities,

--- a/content/00.build/30.zksync-sso/10.architecture.md
+++ b/content/00.build/30.zksync-sso/10.architecture.md
@@ -25,26 +25,30 @@ enhancing security by restricting the scope and usage of session keys.
 
 ### ZKsync SSO Auth Server
 
-The **Auth Server** is a stateless, off-chain hosted service (provided by ZKsync as a public good) that facilitates key aspects of the authentication process.
-It acts as an intermediary between the client application and the ZKsync chain, handling:
+The **Auth Server** is a single-page-application
+(provided by ZKsync as a public good)
+that facilitates key aspects of the authentication process.
+It acts as a non-custodial intermediary between the client application and the ZKsync chain, handling:
 
 - **Passkey Creation:** Assists in generating and managing user passkeys for secure authentication.
-- **Session Creation:** Manages user sessions, including session keys with their associated permissions/spend limits.
+- **Session Settings:** Manages user sessions, including session keys with their associated permissions/spend limits.
 - **Transaction Signatures:** Facilitates the signing of transactions.
 
-This server ensures that sensitive operations are handled securely and efficiently without exposing
+This component ensures that sensitive operations are handled securely and efficiently without exposing
 private keys or requiring users to manage complex cryptographic details.
+Hosting this on a trusted domain allows for multiple applications to easily interoperate, while storing all data
+on-chain for the full benefits of decentralization.
 
 ## Smart Contracts
 
-A set of smart contracts deployed on the ZKsync chain manage accounts, authentication modules, and session keys.
+A set of smart contracts deployed on the ZKsync chain manage accounts, passkeys, and sessions.
 These contracts form the on-chain backbone of the ZKsync SSO system.
 
-- **ERC7579Account.** Implements the ERC-7579 standard for modular smart contract accounts, allowing for extensible account functionalities.
+- **ERC7579Account.** Implements the ZKSync modular account standard, allowing for extensible smart account functionalities.
 - **AAFactory.** A factory contract used to deploy new user accounts on the chain efficiently.
 - **SessionKeyValidator.** Manages session keys with specific spend limits, enhancing security by restricting their scope and usage.
 - **WebAuthnModule.** Handles authentication using WebAuthn standards, enabling passkey-based authentication methods.
-- **Account Proxies.** Each user account is associated with an account proxy, facilitating interactions with the user's smart contract account.
+- **Account Proxies.** Each user account is an upgradable proxy contract for the ZKsync smart-sign-on implemention.
 
 ## Diagram
 

--- a/content/00.build/30.zksync-sso/20.features.md
+++ b/content/00.build/30.zksync-sso/20.features.md
@@ -3,17 +3,18 @@ title: Features
 description: Learn about the features of ZKsync SSO.
 ---
 
-## Passkeys Authentication
+## Passkey Authentication
 
 Passkeys are a core feature supported by ZKsync SSO that enable secure,
 passwordless authentication for users interacting with applications on the ZK Chain.
-Stored on users' devices, these passkeys make for a self-custodial and secure solution.
-ZKsync SSO also supports biometric authentication methods like Face ID and fingerprint recognition, utilizing the secp256r1 elliptic curve.
+Stored on users' devices, these passkeys make for a self-custodial and secure solution to private key management.
+This standard also supports biometric authentication methods like Face ID and fingerprint recognition,
+ utilizing the secp256r1 elliptic curve via native precompile in ZKsync.
 
 ## Sessions and Spend Limits
 
-A session is a temporary, limited-permission access to an account governed by a configurable policy.
-Sessions are explicitly approved by account owners and are managed via session keys.
+A session is a time-limited, limited-permission key to an account governed by a configurable policy.
+Sessions are explicitly approved by account owners and can be revoked or removed after creation.
 A session key owner can execute a restricted set of transactions from the account without requiring the account owner’s signature.
 
 When an application requests a session, it specifies the desired spend limits, which the account owner can approve.
@@ -31,6 +32,12 @@ This means if one device is lost, the passkeys are still accessible on other syn
 *More account recovery options are coming soon*
 
 <!--
+**Adding another auth page — *coming soon**?*
+To avoid the reliance on a single trusted domain,
+users can create or connect to a ZKsync SSO auth page hosted on a different domain!
+By providing their account address, the alternate page can provide a great back-up location for passkeys.
+These passkeys could be stored via FIDO device or a different online passkey provider than the primary key.
+
 **Adding another passkey — *coming soon***
 
 Users can register a new device by adding a new passkey to their account.
@@ -59,6 +66,10 @@ ZKsync SSO provides a dashboard where users can conveniently manage their accoun
 
 ## Modular
 
-Developers can enhance the functionality of ZKsync SSO by implementing ERC-7579 modules.
-[ERC-7579](https://eips.ethereum.org/EIPS/eip-7579) is a standard that allows for modular extensions to smart contract wallets,
-enabling custom features to be added seamlessly.
+Developers can enhance the functionality of ZKsync SSO accounts by implementing compatible modules via smart contracts.
+The module interface is based on [ERC-7579](https://eips.ethereum.org/EIPS/eip-7579#modules)
+to allow maximum flexibility while using ZKsync's powerful native account abstraction to developer overhead.
+
+The existing passkey and session features are already implemented as modules,
+and installed by default on new account deployment.
+Modules can be added or removed from the account, without having to migrate or upgrade the whole account!

--- a/content/00.build/30.zksync-sso/25.interfaces.md
+++ b/content/00.build/30.zksync-sso/25.interfaces.md
@@ -3,18 +3,171 @@ title: Interfaces
 description: Get familiar with ZKsync SSO interfaces
 ---
 
-This document will explicitly list each interface method supported by the super-set account and module, along with brief descriptions of each method.
-It is important to clarify the distinction between the module interface and the account interface:
+There are 3 major components to the SDK: the hosted auth page, the client, and the contracts.
+While the internal functionality can be quite complex, the external interfaces for developers are very simple.
+This provides some technical information on how these components can be used.
+
+### Auth Server
+
+This should be the primary entry-point for those not-looking to create an embedded wallet experience.
+The key entrypoint to the SDK is via the ``zksyncAccountConnector`` to connect to the *Auth Server*.
+This takes the auth domain, session, and basic app information (name, icon). The fully expanded type looks like:
+
+```ts
+type ZKsyncAccountConnectorOptions = {
+  metadata?: {
+    name: string,
+    icon?: string,
+  },
+  session?: {
+    expiresAt?: Date| bigint;
+    feeLimit?: bigint | ({ limit: bigint; period?: bigint; });
+    callPolicies?: ({
+        target: Address;
+        function?: string | AbiFunction;
+        selector?: Hash; // if function is not provided
+        maxValuePerUse?: bigint;
+        valueLimit?: bigint | Limit;
+        constraints?: {
+            index: number | bigint;
+            condition?: Condition | keyof typeof Condition;
+            refValue?: Hash;
+            limit?: Limit;
+        },
+    })[];
+    transferPolicies?: (
+        target: Address;
+        maxValuePerUse?: bigint;
+        valueLimit?: bigint | Limit;)[];
+  },
+  authServerUrl?: string;
+};
+```
+
+This returns a [WAGMI connector](https://wagmi.sh/core/api/connectors) that can be used to perform wallet-like
+actions with the available account.
+All of the functionality is then exposed via WAGMI,
+making the ZKsync SSO account nearly indistinguishable from any other standard wallet provider!
+
+### Client
+
+For embedded wallet use cases that don't use the hosted auth solution,
+the two key entry points are `registerNewPasskey` and `deployAccount`.
+Adding a new passkey only really requires a username and the domain to store it for!
+
+The passkey creation is handled by the simplewebauthn packages,
+so it either takes the options to [generate](https://simplewebauthn.dev/docs/advanced/passkeys#generateregistrationoptions) a new key,
+or it takes options to [login](https://simplewebauthn.dev/docs/packages/server#1-generate-authentication-options)
+with an existing key!
+
+Account deployment allows for changing the default modules included with the account,
+so using the passkey or spend-limit modules here will hurt interoperability.
+The deployment interface includes the following:
+
+```ts
+type DeployAccountArgs = {
+  credentialPublicKey: Uint8Array; // Public key of the previously registered passkey
+  paymasterAddress?: Address; // Paymaster used to pay the fees of creating accounts
+  paymasterInput?: Hex; // Input for paymaster (if provided)
+  expectedOrigin?: string; // Expected origin of the passkey
+  uniqueAccountId?: string; // Unique account ID, can be omitted if you don't need it
+  contracts: {
+    accountFactory: Address;
+    passkey: Address;
+    session: Address;
+  };
+  initialSession?: SessionData;
+  salt?: Uint8Array; // deployment hash
+};
+```
+
+## Sessions
+
+Sessions' combination of function selector and multiple layers of limits makes them effective security measures,
+but they must be configured correctly in order to be most specific to the expected use cases.
+The session interface is also included with the account and passkey creation interfaces so sessions can be created
+during any important user interactions.
+
+```typescript
+type CallPolicy = {
+  target: Address;
+  function?: string | AbiFunction;
+  selector?: Hash; // if function is not provided
+  maxValuePerUse?: bigint;
+  valueLimit?: bigint | Limit;
+  constraints?: {
+    index: number | bigint;
+    condition?: Condition | keyof typeof Condition;
+    refValue?: Hash;
+    limit?: Limit;
+  }[];
+};
+
+type CallPolicy = {
+  target: Address;
+  function?: string | AbiFunction;
+  selector?: Hash; // if function is not provided
+  maxValuePerUse?: bigint;
+  valueLimit?: bigint | Limit;
+  constraints?: {
+    index: number | bigint;
+    condition?: Condition | keyof typeof Condition;
+    refValue?: Hash;
+    limit?: Limit;
+  }[];
+};
+
+type CallPolicy = {
+  target: Address;
+  function?: string | AbiFunction;
+  selector?: Hash; // if function is not provided
+  maxValuePerUse?: bigint;
+  valueLimit?: bigint | Limit;
+  constraints?: {
+    index: number | bigint;
+    condition?: Condition | keyof typeof Condition;
+    refValue?: Hash;
+    limit?: Limit;
+  }[];
+};
+
+type TransferPolicy = {
+  target: Address;
+  maxValuePerUse?: bigint;
+  valueLimit?: bigint | Limit;
+};
+
+interface SessionPreferences {
+  expiresAt?: bigint;
+  feeLimit?: bigint | Limit;
+  callPolicies?: CallPolicy[];
+  transferPolicies?: TransferPolicy[];
+};
+
+```
+
+This design was inspired by [Smart Sessions](https://github.com/erc7579/smartsessions/blob/main/contracts/external/policies/UniActionPolicy.sol).
+For those looking to configure sessions to restrict access to functions,
+understanding the storage layout of the sessions will help when setting the function selector and limits.
+
+The split between call policy and transfer policy means that only *one* policy will be enforced per account transaction,
+and it will be determined based on the amount of data provided.
+4 or more bytes triggers the call policy, otherwise the transfer policy is applied.
+
+## Modules
+
+It is important to clarify the distinction between the solidity module interface and the account interface:
 the module interface specifies the methods that external contracts need to implement,
 whereas the account interface defines the methods that the smart account must support.
+When writing new custom modules it's helpful to know how accounts will interface, so both are provided here for completeness.
 
-## ZKsync SSO specific functions
+### ZKsync SSO Account specific functions
 
 - `validateTransaction` - accepts a signature and the full transaction to execute, including paymaster information.
 - `executeTransaction` - invoked by ZKsync's entry point to run a verified transaction
 - `payForTransaction` and `prepareForPaymaster` - paymaster parsing functions called by the entry point to handle transaction fees and paymaster data.
 
-## Account functions from 7579
+### Account functions from 7579
 
 - `executeFromExecutor` - a special entry point for modules that have been granted permission to execute within the smart account.
 - `accountId` - returns a unique identifier for the contract type
@@ -24,81 +177,17 @@ whereas the account interface defines the methods that the smart account must su
 - `uninstallModule` - removes a module from the account
 - `isModuleInstalled` - checks if a module is installed on the account
 
-## Hooks
+### Hooks
 
 - `preCheck` - called before the execution flow begins
 - `postCheck` - called after the execution flow completes
 
-## Sessions
-
-Each allowed `(address, selector)` pair will have an assigned `FunctionPolicy` with all the applied constraints.
-`FunctionPolicy` will have a list of constraints on its arguments, as well as optional cumulative limits and allowances.
-
-```solidity
-// signer => session
-mapping(address => SessionPolicy) sessions;
-
-struct SessionPolicy {
-    // (target, selector) => function policy
-    mapping(address => mapping(bytes4 => FunctionPolicy)) policy;
-    // timestamp when this session expires
-    uint256 expiry;
-    // to close the session early, flip this flag
-    bool isOpen;
-}
-
-struct FunctionPolicy {
-    // this flag is needed, as otherwise, an empty FunctionPolicy (default mapping entry)
-    // would mean no constraints
-    bool isAllowed;
-    uint256 maxValuePerUse;
-    LimitUsage valueUsage;
-    Constraint[] paramConstraints;
-}
-
-struct Constraint {
-    Condition condition;
-    uint64 offset;
-    bytes32 refValue;
-    // Lifetime cumulative limit (optional)
-    LimitUsage usage;
-    // Cumulative limit per time period (optional)
-    Allowance allowance;
-}
-
-struct LimitUsage {
-    bool isLimited;
-    uint256 limit;
-    uint256 used;
-}
-
-struct Allowance {
-    bool isLimited;
-    uint256 timePeriod;
-    uint256 limit;
-    // period => used that period
-    mapping(uint256 => uint256) used;
-}
-
-enum Condition {
-    EQUAL,
-    GREATER_THAN,
-    LESS_THAN,
-    GREATER_THAN_OR_EQUAL,
-    LESS_THAN_OR_EQUAL,
-    NOT_EQUAL,
-    NOT_CONSTRAINED
-}
-```
-
-This Design was inspired by [Smart Sessions](https://github.com/erc7579/smartsessions/blob/main/contracts/external/policies/UniActionPolicy.sol)
-
-## 4337 Module flow specific functions
+### 4337 Module flow specific functions
 
 - `validateUserOp` - performs validation of a user operation as defined in ERC-4337
 - `executeUserOp` - called by the ERC-4337 account entry point after validations are successful to execute the user operation
 
-## ZKsync Module flow specific functions
+### ZKsync Module flow specific functions
 
 - `handleTransaction` - uses the same format as EIP1271 `isValidSignature`
   - Returns true/false instead of a magic success number, easily wrapping an `isValidSignature` call


### PR DESCRIPTION
Replacing unrelated interface information with typescript types. Also changes in copy to better reflect the standard compliance.

## Additional context

Opening a PR instead of pushing commits directly to another branch