### PR TITLE
docs: explain windows 10 alg limitation

### DIFF
--- a/content/00.build/30.zksync-sso/60.supported-environments.md
+++ b/content/00.build/30.zksync-sso/60.supported-environments.md
@@ -13,6 +13,17 @@ ZKsync SSO currently supports web applications through its JavaScript SDK, allow
 - **Microsoft Edge**
 - **Opera**
 
+See the full list of specific versions [here](https://caniuse.com/webauthn).
+
 This broad browser support ensures a smooth user experience across various platforms.
+
+## Coming Soon
+
+Windows 10 users with [Windows Hello](https://www.microsoft.com/en-us/windows/tips/windows-hello) will
+not be able to use PIN or facial recognition until RS256 support is added in a future module.
+Until then, using a mobile device or a password manager will be required to create compatable passkeys on Windows 10.
+The user may still see these options, but will be unable to create an account with the passkey on this platform.
+
+### Native Mobile Integrations
 
 iOS and Android mobile SDKs are *coming soon* and will enable developers to incorporate ZKsync SSO features into native mobile applications.


### PR DESCRIPTION


# Description

Because windows 10 only supports RS256, it's not supported by our ES256
verifier, so until we add an RS256 verifier this platform won't work.
We've attempted to limit these sign-ups via the browser, but it doesn't
appear to stop users from choosing that option. Documenting it is the
next best thing, but we'll probably add a more explicit error next.

## Linked Issues

https://github.com/matter-labs/zksync-account-sdk/issues/182

## Additional context

The current NFT demo (as of this writing) will also fail for Windows 11, so it requires a small update so these docs are correct