### PR TITLE
fix: update broken links

### DIFF
--- a/content/10.zk-stack/10.components/70.compiler/20.specification/70.binary-layout.md
+++ b/content/10.zk-stack/10.components/70.compiler/20.specification/70.binary-layout.md
@@ -365,5 +365,5 @@ contract, its YUL code, assembly), the hash value may be different.
 
 Currently either the hash is computed as `keccak256`, or it is omitted completely.
 
-- [Definition of metadata hash.](https://github.com/matter-labs/era-compiler-solidity/blob/main/era-compiler-solidity/src/project/contract/metadata.rs)
+- [Definition of metadata hash.](https://github.com/matter-labs/era-compiler-solidity/blob/main/docs/src/02-command-line-interface.md#--metadata)
 - [Front-end code that passes hash to the assembly.](https://github.com/matter-labs/era-compiler-solidity/blob/main/era-compiler-solidity/src/project/contract/mod.rs#L106)

--- a/content/10.zk-stack/10.components/70.compiler/20.specification/70.binary-layout.md
+++ b/content/10.zk-stack/10.components/70.compiler/20.specification/70.binary-layout.md
@@ -365,5 +365,5 @@ contract, its YUL code, assembly), the hash value may be different.
 
 Currently either the hash is computed as `keccak256`, or it is omitted completely.
 
-- [Definition of metadata hash.](https://github.com/matter-labs/era-compiler-solidity/blob/main/src/project/contract/metadata.rs)
-- [Front-end code that passes hash to the assembly.](https://github.com/matter-labs/era-compiler-solidity/blob/main/src/project/contract/mod.rs#L146)
+- [Definition of metadata hash.](https://github.com/matter-labs/era-compiler-solidity/blob/main/era-compiler-solidity/src/project/contract/metadata.rs)
+- [Front-end code that passes hash to the assembly.](https://github.com/matter-labs/era-compiler-solidity/blob/main/era-compiler-solidity/src/project/contract/mod.rs#L106)

--- a/content/10.zk-stack/10.components/70.compiler/20.specification/70.binary-layout.md
+++ b/content/10.zk-stack/10.components/70.compiler/20.specification/70.binary-layout.md
@@ -366,4 +366,4 @@ contract, its YUL code, assembly), the hash value may be different.
 Currently either the hash is computed as `keccak256`, or it is omitted completely.
 
 - [Definition of metadata hash.](https://github.com/matter-labs/era-compiler-solidity/blob/main/docs/src/02-command-line-interface.md#--metadata)
-- [Front-end code that passes hash to the assembly.](https://github.com/matter-labs/era-compiler-solidity/blob/main/era-compiler-solidity/src/project/contract/mod.rs#L106)
+- [Front-end code that passes hash to the assembly.](https://github.com/matter-labs/era-compiler-solidity/blob/main/docs/src/02-command-line-interface.md#--metadata-hash)

--- a/content/10.zk-stack/10.components/70.compiler/20.specification/70.binary-layout.md
+++ b/content/10.zk-stack/10.components/70.compiler/20.specification/70.binary-layout.md
@@ -361,9 +361,7 @@ It is placed immediately after the code region and contains:
 An optional, implementation-defined hash of the contract metadata, which may include its
 source.
 Depending on the initial layer where the compilation starts (a Solidity
-contract, its YUL code, assembly), the hash value may be different.
+contract, its Yul code, assembly), the hash value may be different.
 
-Currently either the hash is computed as `keccak256`, or it is omitted completely.
-
-- [Definition of metadata hash.](https://github.com/matter-labs/era-compiler-solidity/blob/main/docs/src/02-command-line-interface.md#--metadata)
-- [Front-end code that passes hash to the assembly.](https://github.com/matter-labs/era-compiler-solidity/blob/main/docs/src/02-command-line-interface.md#--metadata-hash)
+- [Metadata usage and definition.](https://github.com/matter-labs/era-compiler-solidity/blob/main/docs/src/02-command-line-interface.md#--metadata)
+- [Supported metadata hash types.](https://github.com/matter-labs/era-compiler-solidity/blob/main/docs/src/02-command-line-interface.md#--metadata-hash)


### PR DESCRIPTION
<!--

Thank you for contributing to the ZKsync Docs!

Before submitting the PR, please make sure you do the following:

- Update your PR title to follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- Read the [Contributing Guide](https://github.com/matter-labs/zksync-docs/blob/main/CONTRIBUTING.md).
- Understand our [Code of Conduct](https://github.com/matter-labs/zksync-docs/blob/main/CODE_OF_CONDUCT.md)
- Please delete any unused parts of the template when submitting your PR

-->

# Description

Links are broken for the `era-compiler-solidity` repo, as it looks like that repo was refactored
