### PR TITLE
fix: typo in precompiles docs

### DIFF
--- a/content/10.zk-stack/10.components/50.zksync-evm/20.precompiles.md
+++ b/content/10.zk-stack/10.components/50.zksync-evm/20.precompiles.md
@@ -56,7 +56,7 @@ EVM, but not on zkEVM and opposite.
 
 One such very inefficient command is `mulmod`. On EVM there is a native opcode that makes modulo multiplication and it
 costs only 8 gas, which compared to the other opcodes costs is only 2-3 times more expensive. On zkEVM we don’t have
-native `mulmod` opcode, instead, the compiler does full-with multiplication (e.g. it multiplies two `uint256`s and gets
+native `mulmod` opcode, instead, the compiler does full-width multiplication (e.g. it multiplies two `uint256`s and gets
 as a result an `uint512`). Then the compiler performs long division for reduction (but only the remainder is kept), in
 the generic form it is an expensive operation and costs many opcode executions, which can’t be compared to the cost of
 one opcode execution. The worst thing is that `mulmod` is used a lot for the modulo inversion, so optimizing this one


### PR DESCRIPTION
Fixes a typo in discussion of `mulmod`