### PR TITLE
fix: libraries docs typo

### DIFF
--- a/content/00.build/65.developer-reference/30.ethereum-differences/30.libraries.md
+++ b/content/00.build/65.developer-reference/30.ethereum-differences/30.libraries.md
@@ -11,4 +11,4 @@ in IRs: `linkersymbol` in Yul and `PUSHLIB` in EVM legacy assembly.
 
 All linking happens at compile-time. Deploy-time linking is not supported.
 
-For compiling non-linable libraries please refer to the documentation [here](/build/tooling/hardhat/guides/compiling-libraries).
+For compiling non-linkable libraries please refer to the documentation [here](/build/tooling/hardhat/guides/compiling-libraries).


### PR DESCRIPTION
Fixes a typo in the libraries developer reference