### PR TITLE
docs: --constructor-args needs to be final flag in foundry

### DIFF
--- a/content/00.build/40.tooling/30.foundry/20.getting-started.md
+++ b/content/00.build/40.tooling/30.foundry/20.getting-started.md
@@ -112,7 +112,7 @@ contract Greeter {
 </details>
 
 ```bash
-forge create src/Greeter.sol:Greeter --constructor-args "Hello ZKsync" --account myKeystore --sender <KEYSTORE_ADDRESS> --rpc-url %%zk_testnet_rpc_url%% --chain %%zk_testnet_chain_id%% --zksync
+forge create src/Greeter.sol:Greeter --account myKeystore --sender <KEYSTORE_ADDRESS> --rpc-url %%zk_testnet_rpc_url%% --chain %%zk_testnet_chain_id%% --zksync --constructor-args "Hello ZKsync"
 ```
 
 ### Verifying Contracts with `forge`
@@ -122,7 +122,6 @@ Here's an example command:
 
 ```sh
 forge create src/Greeter.sol:Greeter \
-  --constructor-args "Hello ZKsync" \
   --account myKeystore \
   --sender <KEYSTORE_ADDRESS> \
   --rpc-url %%zk_testnet_rpc_url%% \
@@ -130,7 +129,8 @@ forge create src/Greeter.sol:Greeter \
   --verifier zksync \
   --verifier-url https://explorer.sepolia.era.zksync.dev/contract_verification \
   --verify \
-  --zksync
+  --zksync \
+  --constructor-args "Hello ZKsync"
 ```
 
 ### Deploying Factory Contracts


### PR DESCRIPTION
# Description
In foundry, when deploying smart contracts, you need to put the `--constructor-args` flag last.
[Please see Foundry Book for reference]( https://book.getfoundry.sh/reference/forge/forge-create#description)

## Additional context
This was as a consequence of the following error detailed on [stack exchange Ethereum](https://ethereum.stackexchange.com/questions/166853/zksync-deployment-error-server-returned-an-error-response-error-code-3-failed/166854#166854)

Additionally, consider adding the `--legacy` flag to deployment commands in the docs as ZKsync deployments using Foundry require legacy transactions (which are then converted from legacy to zksync deployment transaction to forward them to call the contract deployer contract)