### PR TITLE
docs(tooling): add subgraph tutorial for ZKsync

### DIFF
--- a/content/00.build/40.tooling/01.subgraphs.md
+++ b/content/00.build/40.tooling/01.subgraphs.md
@@ -1,0 +1,133 @@
+---
+title: Query Data
+description: Learn about querying blockchain data on ZKsync using subgraphs on The Graph Network
+---
+
+Getting historical data on smart contracts can be frustrating. The Graph offers a powerful way to query smart contract data with open APIs known as subgraphs.
+
+Subgraphs can be created or queried by anyone, making the data available to the entire ecosystem! The Graph is powered by hundreds of independent Indexers.
+
+Developers can use 100,000 free queries per month by using The Graph Network.
+
+## Quick Start
+
+Subgraphs index emitted events by default (but more functionality can be added later). A subgraph can be created by following these steps:
+
+1. Initialize your subgraph
+2. Publish your subgraph to The Graph Network
+3. Query from your app with your unique API key
+
+Here is a step by step walk through:
+
+## 1. Initialize your subgraph
+
+### Create a subgraph on Subgraph Studio⁠
+
+Go to the [Subgraph Studio](https://thegraph.com/studio/) and connect your wallet. Once your wallet is connected, you can begin by clicking “Create a Subgraph”.
+
+When choosing a name, it's recommended to use Title Case, including the subgraph and chain name, e.g., "MyApp Subgraph ZKsync".
+
+![Create a Subgraph](https://lh7-us.googleusercontent.com/docsz/AD_4nXf8OTdwMxlKQGKzIF_kYR7NPKeh9TmWnZBYxb7ft_YbdOdx_VVtbp6PslN7N1KGUzNpIDCmaXppdrllM1cw_J4L8Na03BXOWzJTK1POCve0nkRjQYgWJ60QHAdtQ4Niy83SMM8m0F0f-N-AJj4PDqDPlA5M?key=fnI6SyFgXU9SZRNX5C5vPQ)
+
+You will then land on your subgraph’s page. All the CLI commands you need will be visible on the right side of the page:
+
+![CLI commands](https://lh7-us.googleusercontent.com/docsz/AD_4nXe3YvCxiOH_LupSWe8zh9AmP-VrV4PlOq3f7Ix6hNlBUYcANUFuLuVIWR74OGiBs0nrugTyT0v3o6RPmTsgHONdv_ZJNWtcDWEkRntXPHlQGFcqmEBa-D6j4aoIPzUKYdOJMVUPu8O3fwjdZ4IaXXZoTzY?key=fnI6SyFgXU9SZRNX5C5vPQ)
+
+### Install the Graph CLI⁠
+
+On your local machine run the following:
+
+```bash
+npm install -g @graphprotocol/graph-cli
+```
+
+### Initialize your Subgraph⁠
+
+You can copy this directly from your subgraph page to include your specific subgraph slug:
+
+```bash
+graph init --studio <SUBGRAPH_SLUG>
+```
+
+You’ll be prompted to provide some info on your subgraph like this:
+
+![cli sample](https://github.com/graphprotocol/docs/blob/584a52ce3ef0e9e745e5a2cc6c9e5f4583306ffe/website/public/img/CLI-Example.png)
+
+Simply have your contract verified on the block explorer and the CLI will automatically obtain the ABI and set up your subgraph.
+
+The default settings will generate an entity for each event.
+
+## 2. Deploy & Publish
+
+### Deploy to Subgraph Studio⁠
+
+First run these commands:
+
+```bash
+graph codegen
+graph build
+```
+
+Then run these to authenticate and deploy your subgraph.
+
+You can copy these commands directly from your subgraph’s page in Subgraph Studio to include your specific deploy key and subgraph slug:
+
+```bash
+graph auth --studio <DEPLOY_KEY>
+graph deploy --studio <SUBGRAPH_SLUG>
+```
+
+You will be asked for a version label. You can enter something like v0.0.1, but you’re free to choose the format.
+
+### Test your subgraph⁠
+
+You can test your subgraph by making a sample query in the playground section. The Details tab will show you an API endpoint.
+
+You can use that endpoint to test from your app.
+
+![Playground](https://lh7-us.googleusercontent.com/docsz/AD_4nXf3afwSins8_eO7BceGPN79VvwolDxmFNUnkPk0zAJCaUA-3-UAAjVvrMzwr7q9vNYWdrEUNgm2De2VfQpWauiT87RkFc-cVfoPSsQbYSgsmwhyY1-tpPdv2J1H4JAMq70nfWBhb8PszZBFjsbDAaJ5eto?key=fnI6SyFgXU9SZRNX5C5vPQ)
+
+### Publish Your Subgraph to The Graph’s Decentralized Network
+
+Once your subgraph is ready to be put into production, you can publish it to the decentralized network.
+
+On your subgraph’s page in Subgraph Studio, click on the Publish button:
+
+![publish button](https://edgeandnode.notion.site/image/https%3A%2F%2Fprod-files-secure.s3.us-west-2.amazonaws.com%2Fa7d6afae-8784-4b15-a90e-ee8f6ee007ba%2F2f9c4526-123d-4164-8ea8-39959c8babbf%2FUntitled.png?table=block&id=37005371-76b4-4780-b044-040a570e3af6&spaceId=a7d6afae-8784-4b15-a90e-ee8f6ee007ba&width=1420&userId=&cache=v2)
+
+Before querying your subgraph, Indexers need to begin serving queries on it. In order to streamline this process, you can curate your subgraph with GRT.
+
+When publishing, you’ll see the option to curate your subgraph.
+
+As of November 2024, it is recommended that you curate your own subgraph with at least 3,000 GRT to ensure that it is indexed and available quickly.
+
+![Publish screen](https://lh7-us.googleusercontent.com/docsz/AD_4nXerUr-IgWjwBZvp9Idvz5hTq8AFB0n_VlXCzyDtUxKaCTANT4gkk-2O77oW-a0ZWOh3hnqQsY7zcSaLeCQin9XU1NTX1RVYOLFX9MuVxBEqcMryqgnGQKx-MbDnOWKuMoLBhgyVWQereg3cdWtCPcTQKFU?key=fnI6SyFgXU9SZRNX5C5vPQ)
+
+> **Note:** The Graph's smart contracts are all on Arbitrum One, even though your subgraph is indexing data from any other [supported chain](https://thegraph.com/docs/en/developing/supported-networks/).
+
+## 3. Query your Subgraph
+
+Congratulations! You can now query your subgraph on the decentralized network!
+
+For any subgraph on the network, you can query it by passing a GraphQL query into the subgraph’s query URL.
+
+Here’s an example from the [CryptoPunks Ethereum subgraph](https://thegraph.com/explorer/subgraphs/HdVdERFUe8h61vm2fDyycHgxjsde5PbB832NHgJfZNqK) by Messari:
+
+![Query URL](https://lh7-us.googleusercontent.com/docsz/AD_4nXebivsPOUjPHAa3UVtvxoYTFXaGBao9pQOAJvFK0S7Uv0scfL6TcTVjmNCzT4DgsIloAQyrPTCqHjFPtmjyrzoKkfSeV28FjS32F9-aJJm0ILAHey2gqMr7Seu4IqPz2d__QotsWG3OKv2dEghiD74eypzs?key=fnI6SyFgXU9SZRNX5C5vPQ)
+
+The query URL for this subgraph is:
+
+`https://gateway-arbitrum.network.thegraph.com/api/`**[api-key]**`/subgraphs/id/HdVdERFUe8h61vm2fDyycgxjsde5PbB832NHgJfZNqK`
+
+Now, you simply need to  fill in your own API Key to start sending GraphQL queries to this endpoint.
+
+### Getting your own API Key
+
+![API keys](https://lh7-us.googleusercontent.com/docsz/AD_4nXdz7H8hSRf2XqrU0jN3p3KbmuptHvQJbhRHOJh67nBfwh8RVnhTsCFDGA_JQUFizyMn7psQO0Vgk6Vy7cKYH47OyTq5PqycB0xxLyF4kSPsT7hYdMv2MEzAo433sJT6VlQbUAzgPnSxKI9a5Tn3ShSzaxI?key=fnI6SyFgXU9SZRNX5C5vPQ)
+
+In Subgraph Studio, you’ll see the “API Keys” menu at the top of the page. Here you can create API Keys.
+
+### Additional resources
+
+- To explore all the ways you can optimize & customize your subgraph for better performance, read more about [creating a subgraph here](https://thegraph.com/docs/en/developing/creating-a-subgraph/).
+- For more information about querying data from your subgraph, read more [here](https://thegraph.com/docs/en/querying/querying-the-graph/).


### PR DESCRIPTION
# Description
This PR adds a new tutorial to the Build/Tooling section of the zkSync documentation. The tutorial guides developers on how to create, deploy, and query subgraphs using The Graph, tailored for the zkSync ecosystem.

Key highlights:
Introduces subgraphs as a solution for querying historical blockchain data.
Provides step-by-step instructions for setting up and deploying subgraphs via Subgraph Studio.
Explains how to query subgraphs using GraphQL with an API key.
Highlights best practices for curating subgraphs with GRT for fast indexing.
This addition will help developers working on zkSync-powered dApps to efficiently access and manage blockchain data.

## Linked Issues
This PR is not linked to an issue. However, it aligns with efforts to improve developer tooling and ecosystem resources.

## Additional Context
The newly added tutorial file is named subgraphs.md and is located in the Build/Tooling directory.