### PR TITLE
docs: add contract repo link

### DIFF
--- a/content/00.build/30.zksync-sso/00.index.md
+++ b/content/00.build/30.zksync-sso/00.index.md
@@ -35,9 +35,11 @@ See [Getting Started](/build/zksync-sso/getting-started) to learn how easy it is
 Need help? Join our [GitHub Discussions](%%zk_git_repo_zksync-developers%%/discussions/)
 to ask questions, share your experiences, and connect with the ZKsync community.
 
-<!---
 ## Source Code
 
-The [ZKsync SSO Project](https://github.com/matter-labs/zksync-sso)
+The [ZKsync SSO SDK](https://github.com/matter-labs/zksync-sso)
 is open-source and available on GitHub under the MIT License.
-Feel free to contribute, report issues, or suggest new features to help us improve the tool for everyone.--->
+Feel free to contribute, report issues, or suggest new features to help us improve the tool for everyone.
+
+The [ZKsync SSO Smart Contracts](https://github.com/matter-labs/zksync-sso-clave-contracts)
+is a fork of [Clave](https://github.com/getclave/clave-contracts) smart contracts, open-source and available on GitHub under the GNU License.


### PR DESCRIPTION
# Description

Add a link to smart contracts repo after we split the SSO monorepo into two repos

# Verification

<img width="1034" alt="image" src="https://github.com/user-attachments/assets/a3820f83-ab4c-4446-adc0-e1c1436fe148">
