### PR TITLE
fix(docs): fix broken link on Quick Start page

### DIFF
--- a/content/10.zk-stack/20.running-a-zk-chain/10.quickstart.md
+++ b/content/10.zk-stack/20.running-a-zk-chain/10.quickstart.md
@@ -5,7 +5,7 @@ description: Quickstart - Getting Started with ZK Stack
 
 ## Development dependencies
 
-Ensure you have followed [these instructions](https://github.com/matter-labs/zksync-era/blob/main/docs/guides/setup-dev.md)
+Ensure you have followed [these instructions](https://github.com/matter-labs/zksync-era/blob/main/docs/src/guides/setup-dev.md)
 to set up dependencies on your machine (don't worry about the Environment section for now).
 
 ## Deploying locally


### PR DESCRIPTION
# Description
Fixing a broken link on Quick Start page: https://docs.zksync.io/zk-stack/running-a-zk-chain/quickstart

Actual:
"Ensure you have followed [these instructions](https://github.com/matter-labs/zksync-era/blob/main/docs/guides/setup-dev.md)"

Expected:
"Ensure you have followed [these instructions](https://github.com/matter-labs/zksync-era/blob/main/docs/src/guides/setup-dev.md)"
