### PR TITLE
chore: pin links in tx filtering doc to the commit

### DIFF
--- a/content/10.zk-stack/40.extending/20.transaction-filtering.md
+++ b/content/10.zk-stack/40.extending/20.transaction-filtering.md
@@ -23,12 +23,12 @@ To disable L1→L2 filtering, the same function that registers the filtered to t
 
 To filter the transactions sent via the API, operators shall include filtering logic before txs get to the mempool.
 
-To do this, an alternative [`TxSinkLayer`](https://github.com/matter-labs/zksync-era/blob/main/core/node/node_framework/src/implementations/layers/web3_api/tx_sink.rs)
+To do this, an alternative [`TxSinkLayer`](https://github.com/matter-labs/zksync-era/blob/7ace594fb3140212bd94ffd6bffcac99805cf4b1/core/node/node_framework/src/implementations/layers/web3_api/tx_sink/master_pool_sink.rs)
 must be implemented and used by the `node framework` by modifying the code
-[here](https://github.com/matter-labs/zksync-era/blob/main/core/bin/zksync_server/src/node_builder.rs#L230).
+[here](https://github.com/matter-labs/zksync-era/blob/7ace594fb3140212bd94ffd6bffcac99805cf4b1/core/bin/zksync_server/src/node_builder.rs#L332).
 For reference,
 
-- See [Node Framework example](https://github.com/matter-labs/zksync-era/blob/main/core/node/node_framework/examples/main_node.rs#L416)
+- See [Node Framework example](https://github.com/matter-labs/zksync-era/blob/7ace594fb3140212bd94ffd6bffcac99805cf4b1/core/node/node_framework/examples/showcase.rs#L253)
 - See [example implementation](https://github.com/matter-labs/zksync-era/pull/1782)
 
 #### Note on Withdrawals


### PR DESCRIPTION
# Description

Pin the links to specific commits, so they don't get broken.
