### PR TITLE
fix: main sso redirect

### DIFF
--- a/redirects.ts
+++ b/redirects.ts
@@ -69,7 +69,7 @@ const docsReorgRedirects = {
   },
 
   // ZKsync SSO
-  '/build/zksync-sso': { redirect: '/zksync-era/unique-features/zksync-sso/getting-started' },
+  '/build/zksync-sso': { redirect: '/zksync-era/unique-features/zksync-sso' },
   '/build/zksync-sso/getting-started': { redirect: '/zksync-era/unique-features/zksync-sso/getting-started' },
   '/build/zksync-sso/architecture': { redirect: '/zksync-era/unique-features/zksync-sso/architecture' },
   '/build/zksync-sso/features': { redirect: '/zksync-era/unique-features/zksync-sso/features' },

--- a/redirects.ts
+++ b/redirects.ts
@@ -69,6 +69,7 @@ const docsReorgRedirects = {
   },
 
   // ZKsync SSO
+  '/build/zksync-sso': { redirect: '/zksync-era/unique-features/zksync-sso/getting-started' },
   '/build/zksync-sso/getting-started': { redirect: '/zksync-era/unique-features/zksync-sso/getting-started' },
   '/build/zksync-sso/architecture': { redirect: '/zksync-era/unique-features/zksync-sso/architecture' },
   '/build/zksync-sso/features': { redirect: '/zksync-era/unique-features/zksync-sso/features' },


### PR DESCRIPTION
# Description
https://docs.zksync.io/build/zksync-sso redirect is still not working, added redirect to https://docs.zksync.io/zksync-era/unique-features/zksync-sso