### PR TITLE
fix: eip-1559 maxPriorityFeePerGas error

### DIFF
--- a/content/20.zksync-protocol/00.rollup/10.transaction-lifecycle.md
+++ b/content/20.zksync-protocol/00.rollup/10.transaction-lifecycle.md
@@ -100,14 +100,12 @@ adds an `accessList` to transactions, which is an array of addresses and storage
 
 ### EIP-1559: `0x2`
 
-Introduced in Ethereum's London update, [EIP-1559: Fee market change for ETH 1.0 chain](https://eips.ethereum.org/EIPS/eip-1559)
-modifies how transaction fees are handled, replacing `gasPrice` with a base fee and allowing users to set `maxPriorityFeePerGas` and `maxFeePerGas`.
+Ethereum's [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) replaces `gasPrice` with a base fee and adds parameters like `maxFeePerGas`.
 
-- `maxPriorityFeePerGas`: Maximum fee users are willing to pay miners as an incentive.
-- `maxFeePerGas`: Overall maximum fee, including the `maxPriorityFeePerGas` and the base fee determined by the network.
+- `maxFeePerGas`: Maximum total fee, including the base fee.
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
-In ZKsync Era, while the EIP-1559 transaction format is supported, the `maxFeePerGas` and `maxPriorityFeePerGas` parameters are not utilized.
+ZKsync Era does not have a concept of priority fees; therefore, the `maxPriorityFeePerGas` parameter is not utilized
 ::
 
 ### EIP-712: `0x71`

--- a/content/20.zksync-protocol/00.rollup/10.transaction-lifecycle.md
+++ b/content/20.zksync-protocol/00.rollup/10.transaction-lifecycle.md
@@ -103,6 +103,7 @@ adds an `accessList` to transactions, which is an array of addresses and storage
 Ethereum's [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) replaces `gasPrice` with a base fee and adds parameters like `maxFeePerGas`.
 
 - `maxFeePerGas`: Maximum total fee, including the base fee.
+- `maxPriorityFeePerGas`: Recommended to be set to `0` for ZKsync Era transactions.
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
 ZKsync Era does not have a concept of priority fees; therefore, the `maxPriorityFeePerGas` parameter is not utilized


### PR DESCRIPTION
# Description

Fix typo that mentions `maxFeePerGas` isn't being utilized. Make eip-1559 description less confusing.

## Additional context

This came up from discussion: https://github.com/zkSync-Community-Hub/zksync-developers/discussions/832