### PR TITLE
fix: markdown typos

### DIFF
--- a/content/20.zksync-protocol/10.api/20.ethereum-rpc.md
+++ b/content/20.zksync-protocol/10.api/20.ethereum-rpc.md
@@ -1073,7 +1073,7 @@ Object - A transaction object, or null when no transaction was found:
 
 - **blockHash**: DATA, 32 Bytes - hash of the block where this transaction was in. null when its pending.
 - **blockNumber**: QUANTITY - block number where this transaction was in. null when its pending.
-- from: DATA, 20 Bytes - address of the sender.
+- **from**: DATA, 20 Bytes - address of the sender.
 - **gas**: QUANTITY - gas provided by the sender.
 - **gasPrice**: QUANTITY - gas price provided by the sender in Wei.
 - **hash**: DATA, 32 Bytes - hash of the transaction.
@@ -1081,7 +1081,7 @@ Object - A transaction object, or null when no transaction was found:
 - **nonce**: QUANTITY - the number of transactions made by the sender prior to this one.
 - **to**: DATA, 20 Bytes - address of the receiver. null when its a contract creation transaction.
 - **transactionIndex**: QUANTITY - integer of the transactions index position in the block. null when its pending.
-value: QUANTITY - value transferred in Wei.
+- **value** : QUANTITY - value transferred in Wei.
 - **v**: QUANTITY - ECDSA recovery id
 - **r**: QUANTITY - ECDSA signature r
 - **s**: QUANTITY - ECDSA signature s
@@ -1213,13 +1213,13 @@ Object - A transaction receipt object, or null when no receipt was found:
 - **transactionHash** : DATA, 32 Bytes - hash of the transaction.
 - **transactionIndex**: QUANTITY - integer of the transactions index position in the block.
 - **blockHash**: DATA, 32 Bytes - hash of the block where this transaction was in.
-- blockNumber: QUANTITY - block number where this transaction was in.
+- **blockNumber**: QUANTITY - block number where this transaction was in.
 - **from**: DATA, 20 Bytes - address of the sender.
-- **to**: DATA, 20 Bytes - address of the receiver. null when its a contract creation transaction.
+- **to**: DATA, 20 Bytes - address of the receiver.
 - **cumulativeGasUsed** : QUANTITY - The total amount of gas used when this transaction was executed in the block.
 - **effectiveGasPrice** : QUANTITY - The sum of the base fee and tip paid per unit of gas.
 - **gasUsed** : QUANTITY - The amount of gas used by this specific transaction alone.
-contractAddress : DATA, 20 Bytes - The contract address created, if the transaction was a contract creation, otherwise null.
+- **contractAddress** : DATA, 20 Bytes - The contract address created, if the transaction was a contract creation, otherwise null.
 - **logs**: Array - Array of log objects, which this transaction generated.
 - **logsBloom**: DATA, 256 Bytes - Bloom filter for light clients to quickly retrieve related logs.
 - **type**: QUANTITY - integer of the transaction type, 0x0 for legacy transactions, 0x1 for access list types, 0x2 for dynamic fees.


### PR DESCRIPTION

# Description

Typos in markdown format in API page reported in https://github.com/matter-labs/zksync-docs/issues/295

## Linked Issues

fixes #295 

## Additional context
