### PR TITLE
fix typo Update 80.oracles.md

### DIFF
--- a/content/00.zksync-era/60.ecosystem/80.oracles.md
+++ b/content/00.zksync-era/60.ecosystem/80.oracles.md
@@ -41,7 +41,7 @@ trusted, high-volume DEXs and CEXs. Check out the usage guide below to get start
 [Gelato](https://docs.gelato.network/web3-services/vrf/understanding-vrf) provides access to Verifiable Random
 Functions (VRF) on ZKsync. VRFs are cryptographic primitives that generate pseudorandom numbers in a way that is
 provably secure and verifiable. A VRF allows a holder of a private key to produce a random number along with a proof
-that the number was generated legitimately (making it publically verifiable). More information, including how to use
+that the number was generated legitimately (making it publicly verifiable). More information, including how to use
 VRFs in your dApp, can be found in the Gelato docs.
 
 ## Pyth


### PR DESCRIPTION
### Title:
Fix typo in 80.oracles.md

### Description:
This pull request fixes the typo "publically" to "publicly" in the `80.oracles.md` file.

### Changes:
- Corrected the typo: "publically" to "publicly" in the `80.oracles.md` file.

---

Please let me know if any further changes are needed.
