### PR TITLE
fix typo Update 90.node-providers.md

### DIFF
--- a/content/00.zksync-era/60.ecosystem/90.node-providers.md
+++ b/content/00.zksync-era/60.ecosystem/90.node-providers.md
@@ -63,7 +63,7 @@ service, meaning calls to the network are routed to
 Infura provides Open Beta access to ZKsync Era. During this period, there might be feature
 limitations. Performance issues are not expected, but they are possible as we optimize
 and stabilize the service.
-[Read more about ZKsync API acccess through Infura.](https://docs.infura.io/api/networks/zksync)
+[Read more about ZKsync API access through Infura.](https://docs.infura.io/api/networks/zksync)
 
 [Sign up for a free Infura account here.](https://docs.infura.io/dashboard)
 


### PR DESCRIPTION
### Title:
Fix typo in `90.node-providers.md`

### Description:
This pull request corrects a typo in the `90.node-providers.md` file:

- Fixed "acccess" to "access" for proper spelling.

Thanks for reviewing this small update!
