### PR TITLE
fix typo Update 25.zksync-cli-dev.md

### DIFF
--- a/content/00.zksync-era/40.tooling/90.zksync-cli/90.reference/25.zksync-cli-dev.md
+++ b/content/00.zksync-era/40.tooling/90.zksync-cli/90.reference/25.zksync-cli-dev.md
@@ -87,7 +87,7 @@ Update a ZKsync CLI dev module version.
 
 ::field-group
   ::field{name="--force" type="boolean"}
-  Force upddate the module (skip version check).
+  Force update the module (skip version check).
   ::
   ::field{name="--package" type="boolean"}
   Update the NPM package instead of module.


### PR DESCRIPTION
### **Title**:  
Fix typo in 25.zksync-cli-dev.md

### **Description**:  
This pull request corrects a typo in the `25.zksync-cli-dev.md` documentation file. The word "upddate" was changed to "update" for clarity.

### **Changes Made**:  
- Corrected the typo from `upddate` to `update` in the following line:  
  From: `Force upddate the module (skip version check).`  
  To: `Force update the module (skip version check).`

### **Testing/Validation**:  
- No testing required, as this is a documentation fix.

### **Related Issues**:  
- No related issues.

### **Checklist**:  
- [x] Code follows the project's coding style
- [x] Documentation has been updated
- [x] PR is ready for review
