### PR TITLE
fix: typo docs

### DIFF
--- a/content/00.zksync-era/10.guides/20.zksync-101/_upgrading/_transparent_proxy_contract_upgradability.md
+++ b/content/00.zksync-era/10.guides/20.zksync-101/_upgrading/_transparent_proxy_contract_upgradability.md
@@ -102,7 +102,7 @@ funding goal, without any time constraints.
 
 **Proposed Upgrade:**
 
-We're introducing a dealine on creation of a crowdfunding campaign.
+We're introducing a deadline on creation of a crowdfunding campaign.
 Contributions can only be made within the allowed time period.
 
 **Enhanced Contract:**


### PR DESCRIPTION
fix minor typo and update.
# Description

At the [Upgradability](https://docs.zksync.io/zksync-era/guides/zksync-101/upgrading) docs page there is minor typo.
changed from **"dealine"** to **"dealdine"** 

![image](https://github.com/user-attachments/assets/ee5c08a2-0988-499a-a3de-ff32d5bf6ab8)
