### PR TITLE
fix: missed precompiles

### DIFF
--- a/content/20.zksync-protocol/70.differences/40.pre-compiles.md
+++ b/content/20.zksync-protocol/70.differences/40.pre-compiles.md
@@ -13,7 +13,9 @@ It's important to be aware that the gas costs and behaviors of these precompiles
 
 | Address | Name | Description |
 |---------|------|-------------|
-|  `0x06`       | ecAdd     |  Point addition (ADD) on the elliptic curve 'alt_bn128'           |
-|  `0x07`       | ecMul     |  Scalar multiplication (MUL) on the elliptic curve 'alt_bn128'           |
-|  `0x08`       | ecParing     | Bilinear function on groups on the elliptic curve 'alt_bn128'            |
-| `0x100`        | p256Verify     | Performs signature verifications in the secp256r1 elliptic curve ([RIP7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md))            |
+|  `0x01` | ecRecover  | Recovers the public key from an ECDSA signature.           |
+|  `0x02` | SHA2-256   | Computes the SHA-256 hash of the input.            |
+|  `0x06` | ecAdd      | Point addition (ADD) on the elliptic curve 'alt_bn128' .          |
+|  `0x07` | ecMul      | Scalar multiplication (MUL) on the elliptic curve 'alt_bn128'.           |
+|  `0x08` | ecParing   | Bilinear function on groups on the elliptic curve 'alt_bn128' .           |
+| `0x100` | p256Verify | Performs signature verifications in the secp256r1 elliptic curve ([RIP7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md))            |


### PR DESCRIPTION
# Description

Adds ecRecover and sha256 to list of precompiles.

## Linked Issues

N/A

## Additional context

identity precompile will be available in the next protocol upgrade