### PR TITLE
feat: adds verification API endpoints

### DIFF
--- a/content/00.zksync-era/20.environment/00.index.md
+++ b/content/00.zksync-era/20.environment/00.index.md
@@ -27,6 +27,7 @@ To manually add ZKsync Era as a custom network in your wallet, follow these step
 - Currency Symbol: `%%zk_mainnet_currency_symbol%%`
 - Block Explorer URL: `%%zk_mainnet_block_explorer_url%%`
 - WebSocket URL: `%%zk_mainnet_websocket_url%%`
+- Explorer Verification API: `%%zk_mainnet_contract_verification_url%%`
 
 ### Sepolia testnet network details
 
@@ -36,6 +37,7 @@ To manually add ZKsync Era as a custom network in your wallet, follow these step
 - Currency Symbol: `%%zk_testnet_currency_symbol%%`
 - Block Explorer URL: `%%zk_testnet_block_explorer_url%%`
 - WebSocket URL: `%%zk_testnet_websocket_url%%`
+- Explorer Verification API: `%%zk_testnet_contract_verification_url%%`
 
 ## Get testnet funds for your wallet
 

--- a/content/00.zksync-era/40.tooling/40.block-explorers.md
+++ b/content/00.zksync-era/40.tooling/40.block-explorers.md
@@ -17,7 +17,7 @@ Feel free to contribute and create issues and feature requests in [ZKsync Era Bl
 
 We’ve developed the ZKsync Era Block Explorer API for developers to access ZKsync Era Block Explorer data directly via HTTP requests.
 
-The API provides various endpoints for many use cases you might want in your app. It is compatible with [Etherscan API](https://docs.etherscan.io/),
+The API provides various endpoints for many use cases you might want in your app. It is compatible with [Etherscan APIs](https://docs.etherscan.io/),
 which makes it easy to transition your existing apps to ZKsync Era network.
 
 - [Mainnet Block Explorer API Swagger](https://block-explorer-api.mainnet.zksync.io/docs)
@@ -25,7 +25,7 @@ which makes it easy to transition your existing apps to ZKsync Era network.
 
 ### Verification API endpoints
 
-The ZKsync Explorer Verification API that allows you to verify smart contracts on the ZKsync Era network. You can use the following
+The ZKsync Explorer Verification API allows you to verify smart contracts on the ZKsync Era network. You can use the following
 endpoints to verify your smart contracts:
 
 | Network | Contract Verification API |

--- a/content/00.zksync-era/40.tooling/40.block-explorers.md
+++ b/content/00.zksync-era/40.tooling/40.block-explorers.md
@@ -3,21 +3,35 @@ title: Block explorers
 description: Learn about the official and 3rd party resources for exploring the ZKsync Era network.
 ---
 
+## ZKsync Explorer
+
 The [ZKsync Era Block Explorer](%%zk_mainnet_block_explorer_url%%)
 details comprehensive data about transactions, blocks, batches, wallets, tokens, and smart contracts on the ZKsync Era network.
 
-## Block Explorer API
+- [ZKsync Era Mainnet Block Explorer](%%zk_mainnet_block_explorer_url%%)
+- [ZKsync Era Testnet Block Explorer](%%zk_testnet_block_explorer_url%%)
+
+Feel free to contribute and create issues and feature requests in [ZKsync Era Block Explorer GitHub repo](%%zk_git_repo_block-explorer%%).
+
+### Block Explorer API
 
 We’ve developed the ZKsync Era Block Explorer API for developers to access ZKsync Era Block Explorer data directly via HTTP requests.
 
-- [Mainnet Block Explorer API](https://block-explorer-api.mainnet.zksync.io/docs)
-- [Testnet Block Explorer API](https://block-explorer-api.sepolia.zksync.dev/docs)
-
-The API provides various endpoints for many use cases you might want in your app.
-It is compatible with [Etherscan API](https://docs.etherscan.io/),
+The API provides various endpoints for many use cases you might want in your app. It is compatible with [Etherscan API](https://docs.etherscan.io/),
 which makes it easy to transition your existing apps to ZKsync Era network.
 
-Feel free to contribute and create issues and feature requests in [ZKsync Era Block Explorer GitHub repo](%%zk_git_repo_block-explorer%%).
+- [Mainnet Block Explorer API Swagger](https://block-explorer-api.mainnet.zksync.io/docs)
+- [Testnet Block Explorer API Swagger](https://block-explorer-api.sepolia.zksync.dev/docs)
+
+### Verification API endpoints
+
+The ZKsync Explorer Verification API that allows you to verify smart contracts on the ZKsync Era network. You can use the following
+endpoints to verify your smart contracts:
+
+| Network | Contract Verification API |
+| --- | --- |
+| Mainnet | `%%zk_mainnet_contract_verification_url%%` |
+| Testnet | `%%zk_testnet_contract_verification_url%%` |
 
 ## Other block explorers
 


### PR DESCRIPTION
# Description

- Adding contract verification API to the ZKsync Era network details page
- Also re-structuring the explorers page to include this information.

## Linked Issues

[In this discussion](https://github.com/zkSync-Community-Hub/zksync-developers/discussions/930) a user was unable to find the info in the docs.

## Additional context

It's pretty hard to find the smart contract verification URLs as currently they're only provided in some hardhat config examples.