### PR TITLE
fix: fix links in zksync protocol

### DIFF
--- a/content/20.zksync-protocol/00.rollup/40.bridging-assets.md
+++ b/content/20.zksync-protocol/00.rollup/40.bridging-assets.md
@@ -65,13 +65,13 @@ every withdrawal, we will take care of it by making an L1 transaction that prove
 To build a custom bridge, create a regular Solidity contract which extends one of
 the interfaces mentioned below for the layer. The interfaces provide access to the ZKsync Era SDK deposit and withdraw implementations.
 
-- L1: [IL1Bridge.sol](https://github.com/matter-labs/era-contracts/blob/main/l1-contracts/contracts/bridge/interfaces/IL1Bridge.sol)
+- L1: [IL1SharedBridge.sol](https://github.com/matter-labs/era-contracts/blob/main/l1-contracts/contracts/bridge/interfaces/IL1SharedBridge.sol)
 
   For more information, check out our example [L1 custom bridge implementation](https://github.com/matter-labs/era-contracts/blob/main/l1-contracts/contracts/bridge/L1ERC20Bridge.sol).
 
-- L2: [IL2Bridge.sol](https://github.com/matter-labs/era-contracts/blob/main/l1-contracts/contracts/bridge/interfaces/IL2Bridge.sol)
+- L2: [IL2SharedBridge.sol](https://github.com/matter-labs/era-contracts/blob/main/l1-contracts/contracts/bridge/interfaces/IL1SharedBridge.sol)
 
-  For more information, check out our example [L2 custom bridge implementation](https://github.com/matter-labs/era-contracts/blob/main/l2-contracts/contracts/bridge/L2ERC20Bridge.sol).
+  For more information, check out our example [L2 custom bridge implementation](https://github.com/matter-labs/era-contracts/blob/main/l2-contracts/contracts/bridge/L2SharedBridge.sol).
 
 ## Adding Tokens to the Bridge UI
 

--- a/content/20.zksync-protocol/00.rollup/70.data-availability.md
+++ b/content/20.zksync-protocol/00.rollup/70.data-availability.md
@@ -5,7 +5,7 @@ description: An in-depth look at how ZKsync ensures data availability through st
 
 Data availability is a cornerstone of ZKsync's architecture,
 ensuring that the entire Layer 2 (L2) state can be
-[reconstructed](https://github.com/matter-labs/zksync-era/blob/main/docs/specs/data_availability/reconstruction.md)
+[reconstructed](https://github.com/matter-labs/zksync-era/blob/main/docs/src/specs/data_availability/reconstruction.md)
 from the data submitted to Ethereum's Layer 1 (L1).
 This process not only secures the network but also optimizes cost-efficiency through innovative data management techniques.
 
@@ -17,7 +17,7 @@ These diffs represent changes in the blockchain's state, enabling ZKsync to effi
 - **Efficient Use of Storage Slots**: Changes to the same storage slots across multiple transactions can be grouped,
   reducing the amount of data that needs to be sent to L1 and thereby lowering gas costs.
 - **Compression Techniques**: All data sent to L1, including state diffs, is compressed to further reduce costs.
-  [Read more about ZKsync's compression methods](https://github.com/matter-labs/zksync-era/blob/main/docs/specs/data_availability/compression.md).
+  [Read more about ZKsync's compression methods](https://github.com/matter-labs/zksync-era/blob/main/docs/src/specs/data_availability/compression.md).
 
 ## Additional data posted to L1
 
@@ -34,7 +34,7 @@ This approach significantly reduces costs by keeping data off-chain but introduc
 
 - **zkPorter**: A hybrid model that combines features of rollups and validiums, zkPorter segments data responsibilities,
 allowing some storage slots to remain off-chain while critical data is posted to L1.
-[Learn more about zkPorter](https://github.com/matter-labs/zksync-era/blob/main/docs/specs/data_availability/validium_zk_porter.md).
+[Learn more about zkPorter](https://github.com/matter-labs/zksync-era/blob/main/docs/src/specs/data_availability/validium_zk_porter.md).
 
 ## Recreating L2 State From L1 Pubdata
 
@@ -80,7 +80,7 @@ with uncompressed bytecode hashes stored in `AccountStorage` for reference.
 
 This process is split into 2 different parts:
 
-- [the server side operator](https://github.com/matter-labs/zksync-era/blob/main/core/lib/utils/src/bytecode.rs#L33) handling the compression
+- [the server side operator](https://github.com/matter-labs/zksync-era/blob/main/core/lib/basic_types/src/bytecode.rs#L55) handling the compression
 - [the system contract](https://github.com/matter-labs/era-contracts/blob/main/system-contracts/contracts/Compressor.sol#L42)
 verifying that the compression is correct before sending to L1.
 


### PR DESCRIPTION
Updated bridging docs to use IL1SharedBridge and IL2SharedBridge Updated data availability docs to use correct links On branch fix-links
Changes to be committed:
modified:   content/20.zksync-protocol/00.rollup/40.bridging-assets.md
modified:   content/20.zksync-protocol/00.rollup/70.data-availability.md

<!--

Thank you for contributing to the ZKsync Docs!

Before submitting the PR, please make sure you do the following:

- Update your PR title to follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- Read the [Contributing Guide](https://github.com/matter-labs/zksync-docs/blob/main/CONTRIBUTING.md).
- Understand our [Code of Conduct](https://github.com/matter-labs/zksync-docs/blob/main/CODE_OF_CONDUCT.md)
- Please delete any unused parts of the template when submitting your PR

-->

# Description

<!-- Please describe what are the changes and what they are solving for in this PR. -->

## Linked Issues

<!-- If you have any issues this PR is related to, link them here. -->
<!--
Check out https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
on how to automate linking a GitHub Issue to a PR.
-->

## Additional context
