### PR TITLE
chore: update docs regarding new hardhat-zksync-node properties

### DIFF
--- a/content/00.zksync-era/40.tooling/20.hardhat/30.plugins/120.hardhat-zksync-node.md
+++ b/content/00.zksync-era/40.tooling/20.hardhat/30.plugins/120.hardhat-zksync-node.md
@@ -60,6 +60,8 @@ Import the plugin in the `hardhat.config.ts` file:
 import "@matterlabs/hardhat-zksync-node";
 ```
 
+To configure a certain version of anvil-zksync or a binary path, the `zksyncAnvil` should be configured properly in the hardhat.config.ts:
+
 ```typescript
   zksyncAnvil: {
         version: '0.3.*', // optional.

--- a/content/00.zksync-era/40.tooling/20.hardhat/30.plugins/120.hardhat-zksync-node.md
+++ b/content/00.zksync-era/40.tooling/20.hardhat/30.plugins/120.hardhat-zksync-node.md
@@ -60,6 +60,18 @@ Import the plugin in the `hardhat.config.ts` file:
 import "@matterlabs/hardhat-zksync-node";
 ```
 
+```typescript
+  zksyncAnvil: {
+        version: '0.3.*', // optional.
+        binaryPath: 'zksync/target/release/anvil-zksync', // optional
+    },
+```
+
+- `version` is the `anvil-zksync` version. The default version is `0.3.*`,
+which resolves to the latest patch version for the specified minor and major version.
+Available options include `latest`, a specific version, or a version with * as the patch to get the latest patch for a given major and minor version.
+- `binaryPath` is binary path to `anvil-zksync` downloaded locally. If this property is set, it will take priority over the version property.
+
 ### Commands
 
 ::code-group
@@ -94,6 +106,7 @@ The command also handles tasks such as downloading the necessary JSON-RPC server
 - `--fork` - Starts a local network that is a fork of another network. Accepted values are: testnet, mainnet, or a specific URL.
 - `--fork-block-number` - Specifies the block height at which to fork.
 - `--replay-tx` - Transaction hash to replay.
+- `--quiet` - Starts in the the quiet mode without logs.
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
 **Parameter Restrictions**:


### PR DESCRIPTION
<!--

Thank you for contributing to the ZKsync Docs!

Before submitting the PR, please make sure you do the following:

- Update your PR title to follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- Read the [Contributing Guide](https://github.com/matter-labs/zksync-docs/blob/main/CONTRIBUTING.md).
- Understand our [Code of Conduct](https://github.com/matter-labs/zksync-docs/blob/main/CODE_OF_CONDUCT.md)
- Please delete any unused parts of the template when submitting your PR

-->

# Description

Update the documentation page for the hardhat-zksync-node plugin to include the new zksyncAnvil object in the Hardhat config file.

```typescript
  zksyncAnvil: {
        version: '0.3.*', // optional.
        binaryPath: 'zksync/target/release/anvil-zksync', // optional
    },
```

- `version` is the `anvil-zksync` version. The default version is `0.3.*`,
which resolves to the latest patch version for the specified minor and major version.
Available options include `latest`, a specific version, or a version with * as the patch to get the latest patch for a given major and minor version.
- `binaryPath` is binary path to `anvil-zksync` downloaded locally. If this property is set, it will take priority over the version property.


## Linked Issues

<!-- If you have any issues this PR is related to, link them here. -->
<!--
Check out https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
on how to automate linking a GitHub Issue to a PR.
-->

## Additional context
