### PR TITLE
fix: broken links to the explorers and bridges pages

### DIFF
--- a/content/00.zksync-era/40.tooling/20.hardhat/30.plugins/60.hardhat-zksync-deploy.md
+++ b/content/00.zksync-era/40.tooling/20.hardhat/30.plugins/60.hardhat-zksync-deploy.md
@@ -21,7 +21,7 @@ If not, please refer to the first section of the [ZKsync 101 material](/zksync-e
 
 You can get Sepolia ETH from the [network faucets](/zksync-era/ecosystem/network-faucets).
 
-- Get testnet `ETH` for ZKsync Era using [bridges](https://zksync.io/explore#bridges) to bridge funds to ZKsync.
+- Get testnet `ETH` for ZKsync Era using [bridges](https://www.zksync.io/era#bridges) to bridge funds to ZKsync.
 - You know [how to get your private key from your MetaMask wallet](https://support.metamask.io/hc/en-us/articles/360015289632-How-to-export-an-account-s-private-key).
 
 ::callout{icon="i-heroicons-information-circle" color="blue"}

--- a/content/00.zksync-era/40.tooling/40.block-explorers.md
+++ b/content/00.zksync-era/40.tooling/40.block-explorers.md
@@ -35,7 +35,7 @@ endpoints to verify your smart contracts:
 
 ## Other block explorers
 
-A full list of ZKsync block explorers can be found on the ZKsync website's [Block Explorers page](https://zksync.io/explore#explorers).
+A full list of ZKsync block explorers can be found on the ZKsync website's [Block Explorers page](https://www.zksync.io/era#explorers).
 
 ### Etherscan - ZKsync Era Explorer
 

--- a/content/20.zksync-protocol/00.rollup/40.bridging-assets.md
+++ b/content/20.zksync-protocol/00.rollup/40.bridging-assets.md
@@ -3,7 +3,7 @@ title: Bridging assets
 description:
 ---
 
-Users can deposit and withdraw assets from ZKsync Era using any of the [multiple bridges](https://zksync.io/explore#bridges).
+Users can deposit and withdraw assets from ZKsync Era using any of the [multiple bridges](https://www.zksync.io/era#bridges).
 
 Under the hood, bridging is implemented by having two contracts
 (one deployed to L1, and the second deployed to L2)


### PR DESCRIPTION
# Description

[zksync.io/explore](http://zksync.io/explore) has been updated to [zksync.io/era](http://zksync.io/era), this PR fixes broken links.