### PR TITLE
feat: remove kado from zksync-easy-onramp section

### DIFF
--- a/content/00.zksync-era/40.tooling/100.zksync-easy-onramp/50.testing-integration.md
+++ b/content/00.zksync-era/40.tooling/100.zksync-easy-onramp/50.testing-integration.md
@@ -25,5 +25,4 @@ Each service may require additional configurations like mock KYC verification. R
 documents for completing sandbox environment setup.
 
 - Transak: <https://docs.transak.com/docs/test-credentials>
-- Kado.money: <https://docs.kado.money/integrations/integrate-kado/sandbox>
 - LI.FI: <https://docs.li.fi/integrate-li.fi-sdk/testing-integration>


### PR DESCRIPTION
# Description

We no longer provide Kado in the On-Ramp SDK. Removing references to them in the docs.


## Additional context

Kado has been acquired and is shutting down their services as part of the transition. 