### PR TITLE
fix: no testnet alert

### DIFF
--- a/content/00.zksync-era/30.unique-features/40.evm-interpreter/01.evm-interpreter.md
+++ b/content/00.zksync-era/30.unique-features/40.evm-interpreter/01.evm-interpreter.md
@@ -5,10 +5,6 @@ description: The special contracts that allows executing EVM bytecode on EraVM
 ZKsync Era integrates an EVM bytecode interpreter that enables compatibility with EVM bytecode.
 The interpreter works by translating EVM instructions into EraVM instructions at execution time.
 
-::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
-At the moment the EVM bytecode interpreter is only available on test blockchains.
-::
-
 This allows developers to deploy and interact with smart contracts without the need of using the ZKsync custom compilers
 (`zksolc` and `zkvyper`). Additionally, standard EVM tooling like Foundry and Hardhat works out of the box without the need
 for [plugins](../../tooling/hardhat/plugins/hardhat-zksync) or [custom versions](../../tooling/foundry/overview).

--- a/content/20.zksync-protocol/75.evm-interpreter/00.overview.md
+++ b/content/20.zksync-protocol/75.evm-interpreter/00.overview.md
@@ -12,10 +12,6 @@ To address this, ZKsync introduces **EVM execution mode via an EVM Bytecode Inte
 on ZK chains **without recompilation or changes to developer tooling**. This enables projects built for Ethereum to execute in
 ZKsync while maintaining EraVM as the core execution environment.
 
-::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
-At the moment the EVM interpretation is only available on test blockchains.
-::
-
 ## Execution Model
 
 - **EraVM remains the primary execution environment.** The EVM Interpreter does not replace EraVM but acts as a **translation layer**,


### PR DESCRIPTION
# Description

Removes interpreter testnet warning message

## Linked Issues

N/A

## Additional context

v27 is live on Era and other mainnets