### PR TITLE
docs: add prividium limitations details

### DIFF
--- a/content/10.zk-stack/35.prividium/20.proxy.md
+++ b/content/10.zk-stack/35.prividium/20.proxy.md
@@ -80,7 +80,7 @@ In a public chain, this mechanism helps ensure censorship resistance for users,
 and allows them to retain full control of their assets.
 
 For Prividium chains though,
-forced transactions can also be vector deploying arbitrary contracts,
+forced transactions can also be a vector for deploying arbitrary contracts,
 performing arbitrary contract writes,
 and leaking data through blind attacks.
 The ZKsync protocol contracts have a way to

--- a/content/10.zk-stack/35.prividium/20.proxy.md
+++ b/content/10.zk-stack/35.prividium/20.proxy.md
@@ -64,3 +64,31 @@ You can see what an example configuration file looks like below:
 :display-partial{path="/zk-stack/prividium/_partials/quickstart/_access"}
 
 The example implementation showcases one approach, but it can be easily modified to accommodate unique workflows or compliance requirements.
+
+## Limitations
+
+### Multicall contract methods
+
+Currently, [multicall](https://docs.chainstack.com/docs/http-batch-request-vs-multicall-contract#multicall-contract) contract methods
+cannot be used in a user's access policy,
+as it would enable bypassing the other access policy rules.
+
+### L1-L2 transactions
+
+L1-L2 transactions, also known as forced transactions, originate from Ethereum (the L1) and can be force included on the L2 chain.
+In a public chain, this mechanism helps ensure censorship resistance for users,
+and allows them to retain full control of their assets.
+
+For Prividium chains though,
+forced transactions can also be vector deploying arbitrary contracts,
+performing arbitrary contract writes,
+and leaking data through blind attacks.
+The ZKsync protocol contracts have a way to
+[request arbitrary transaction](https://github.com/matter-labs/era-contracts/blob/29f9ff4bbe12dc133c852f81acd70e2b4139d6b2/l1-contracts/contracts/bridgehub/Bridgehub.sol#L216)
+to be executed from Ethereum,
+and it can be used to bypass the privacy configuration of a Prividium chain.
+
+Currently **L1-L2 transactions are not automatically disabled** in Prividium chains.
+Prividium chain operators can be protected against malicious use of these forced transactions by implementing [transaction filtering](/zk-stack/extending/transaction-filtering).
+Note that for users, this means that the chain has the ability to censor transactions.
+It is the responsibility of the chain operator to decide how to implement this filtering.


### PR DESCRIPTION
Adds details about multicall and l1-l2 tx filtering limitations for Prividium