### PR TITLE
docs: react native sso sdk supported platforms

### DIFF
--- a/content/00.zksync-era/30.unique-features/30.zksync-sso/10.architecture.md
+++ b/content/00.zksync-era/30.unique-features/30.zksync-sso/10.architecture.md
@@ -20,7 +20,7 @@ enhancing security by restricting the scope and usage of session keys.
 **Platforms:**
 
 - **Web SDK:** Available now, implemented in JavaScript for web applications.
-- **React Native SDK:** For React Native applications
+- **React Native SDK:** For React Native applications targeting iOS and Android.
 - **Swift SDK:** For iOS applications (*coming soon*).
 - **Kotlin SDK:** For Android applications (*coming soon*).
 

--- a/content/00.zksync-era/30.unique-features/30.zksync-sso/5.getting-started.md
+++ b/content/00.zksync-era/30.unique-features/30.zksync-sso/5.getting-started.md
@@ -210,6 +210,7 @@ Just 2 steps:
 
 2. Configure platform-specific settings:
 
+    The React Native SDK currently supports **iOS** and **Android** only.
     Make sure your application is set up to create passkeys by following the platform-specific guidelines:
 
     - **iOS**: Refer to [Apple's documentation](https://developer.apple.com/documentation/authenticationservices/supporting-passkeys)


### PR DESCRIPTION
Document the React Native SSO SDK supported platforms (iOS and Android only).