### PR TITLE
docs: add link to SSO contract addresses

### DIFF
--- a/content/00.zksync-era/30.unique-features/30.zksync-sso/00.index.md
+++ b/content/00.zksync-era/30.unique-features/30.zksync-sso/00.index.md
@@ -6,10 +6,12 @@ description: Learn about ZKsync Smart Sign-on.
 A user & developer friendly modular smart account implementation on ZKsync;
 simplifying user authentication, session management, and transaction processing.
 
+::centered-container
 <video width="640" height="360" controls>
   <source src="/images/zksync-sso/SSO_InANutshell.mp4" type="video/mp4">
   Your browser does not support the video tag.
 </video>
+::
 
 Try our [demo app](https://nft.zksync.dev) to see the great user experience you can offer to your users.
 

--- a/content/00.zksync-era/30.unique-features/30.zksync-sso/10.architecture.md
+++ b/content/00.zksync-era/30.unique-features/30.zksync-sso/10.architecture.md
@@ -84,6 +84,8 @@ Handles authentication using WebAuthn standards, enabling passkey-based authenti
 - [**Account Proxies.**](https://github.com/matter-labs/zksync-sso-clave-contracts/blob/main/src/AccountProxy.sol)
 Each user account is an upgradable proxy contract for the ZKsync smart-sign-on implemention.
 
+The deployed contract addresses for ZKsync Sepolia testnet are available in the [ZKsync SSO repository](https://github.com/matter-labs/zksync-sso/blob/main/packages/auth-server/stores/era-sepolia.json).
+
 ## Diagram
 
 ![zksync sso architecture](/images/zksync-sso/zksync-sso-architecture.png)

--- a/content/00.zksync-era/30.unique-features/30.zksync-sso/100.faqs.md
+++ b/content/00.zksync-era/30.unique-features/30.zksync-sso/100.faqs.md
@@ -35,6 +35,10 @@ Apps can sponsor these fees using a paymaster, allowing users to transact withou
 Developers can integrate ZKsync SSO by using the available SDKs for web applications. Mobile SDKs for iOS and Android are coming soon.
 Refer to the [Getting Started Guide](/zksync-era/unique-features/zksync-sso/getting-started) for detailed instructions.
 
+## Where can I find the deployed SSO contract addresses?
+
+The deployed contract addresses for ZKsync Sepolia testnet are available in the [ZKsync SSO repository](https://github.com/matter-labs/zksync-sso/blob/main/packages/auth-server/stores/era-sepolia.json).
+
 ## Have more questions?
 
 Join our [GitHub Discussions](%%zk_git_repo_zksync-developers%%/discussions/)


### PR DESCRIPTION
Adds a link to SSO contract addresses and centers intro video.