### PR TITLE
feat: testnet paymaster, no ML

### DIFF
--- a/content/00.zksync-era/30.unique-features/10.account-abstraction.md
+++ b/content/00.zksync-era/30.unique-features/10.account-abstraction.md
@@ -1,9 +1,9 @@
 ---
 title: Account Abstraction
-description: Learn about Native Account Abstraction in ZKsync
+description: Learn about Native Account Abstraction in ZKsync Era
 ---
 
-ZKsync protocol natively supports Account Abstraction, making it possible to implement smart accounts
+ZKsync Era natively supports Account Abstraction, making it possible to implement smart accounts
 that contain arbitrary logic, making features like account recovery, native multi-sig accounts, and others.
 
 To learn more about the design of Account Abstraction, see the [Protocol documentation](/zksync-protocol/account-abstraction).

--- a/content/00.zksync-era/30.unique-features/20.paymaster.md
+++ b/content/00.zksync-era/30.unique-features/20.paymaster.md
@@ -1,9 +1,9 @@
 ---
 title: Paymasters
-description: Learn about support for Paymasters in ZKsync
+description: Learn about support for Paymasters in ZKsync Era
 ---
 
-Besides Account Abstraction, ZKsync natively supports paymasters. Introduced in [EIP-4337](https://eips.ethereum.org/EIPS/eip-4337#extension-paymasters),
+Besides Account Abstraction, ZKsync Era natively supports paymasters. Introduced in [EIP-4337](https://eips.ethereum.org/EIPS/eip-4337#extension-paymasters),
 paymasters allow to implement an intermediate step for transaction processing that can alter how the fees are being processed.
 
 This feature can be used for things like:
@@ -15,6 +15,39 @@ This feature can be used for things like:
 ...and many others.
 
 If you want to learn about Paymaster design, see the [protocol documentation](/zksync-protocol/account-abstraction/paymasters).
+
+## Testnet Paymaster
+
+To simplify development and testing, %%zk_testnet_name%% provides a **testnet paymaster** with built-in support for paying fees in ERC20 tokens.
+
+**Key details:**
+
+- **Address**: `0x3cb2b87d10ac01736a65688f3e0fb1b070b3eea3`
+- **Chain**: %%zk_testnet_name%%
+- **Exchange rate**: 1:1 with ETH (1 token unit = 1 wei)
+- **Flow type**: Approval-based only
+- **Usage requirements**:
+  - `token`: must match the ERC20 token used for fee payment
+  - `minimalAllowance`: must be at least `tx.maxFeePerGas * tx.gasLimit`
+  - `innerInput`: must be empty (`0x`)
+
+**Example usage:**
+
+```ts
+const paymasterParams = {
+  paymaster: "0x3cb2b87d10ac01736a65688f3e0fb1b070b3eea3",
+  paymasterInput: {
+    type: "ApprovalBased",
+    token: "<ERC20_TOKEN_ADDRESS>",
+    minimalAllowance: tx.maxFeePerGas * tx.gasLimit, // at least
+    innerInput: "0x",
+  },
+};
+```
+
+This setup allows developers to simulate ERC20-based fee payments in a testnet environment without needing a custom paymaster deployment.
+
+## Paymaster tutorials
 
 If you prefer learning from tutorials, you can check out the following ones:
 

--- a/content/00.zksync-era/30.unique-features/20.paymaster.md
+++ b/content/00.zksync-era/30.unique-features/20.paymaster.md
@@ -22,7 +22,7 @@ To simplify development and testing, %%zk_testnet_name%% provides a **testnet pa
 
 **Key details:**
 
-- **Address**: `0x3cb2b87d10ac01736a65688f3e0fb1b070b3eea3`
+- **Address**: `0x3cb2b87d10ac01736a65688f3e0fb1b070b3eea3` ([see in explorer](https://sepolia.explorer.zksync.io/address/0x3cb2b87d10ac01736a65688f3e0fb1b070b3eea3))
 - **Chain**: %%zk_testnet_name%%
 - **Exchange rate**: 1:1 with ETH (1 token unit = 1 wei)
 - **Flow type**: Approval-based only

--- a/content/00.zksync-era/50.sdk/20.go/30.guides/01.features.md
+++ b/content/00.zksync-era/50.sdk/20.go/30.guides/01.features.md
@@ -31,7 +31,7 @@ The following objects provides support for utilizing ZKsync features:
 ## Encoding paymaster params
 
 While the paymaster feature by itself does not impose any limitations on values of the `paymasterInput`,
-the Matter Labs team endorses certain types of
+the ZKsync protocol endorses certain types of
 [paymaster flows](/zksync-protocol/account-abstraction/paymasters#built-in-paymaster-flows)
 that are processable by EOAs.
 

--- a/content/00.zksync-era/50.sdk/30.python/30.guides/01.features.md
+++ b/content/00.zksync-era/50.sdk/30.python/30.guides/01.features.md
@@ -20,7 +20,7 @@ This document will focus solely on how to pass these arguments to the SDK.
 ## Encoding paymaster params
 
 While the paymaster feature by itself does not impose any limitations on values of the `paymasterInput`,
-the Matter Labs team endorses certain types of paymaster flows that are processable by EOAs.
+the ZKsync protocol endorses certain types of paymaster flows that are processable by EOAs.
 
 ZKsync SDK provides a utility method that can be used to get the correctly formed `paymasterParams` object:
 [PaymasterFlowEncoder](/zksync-era/sdk/python/api/utilities/paymaster-utils#paymasterflowencoder).

--- a/content/00.zksync-era/50.sdk/40.java/20.guides/01.features.md
+++ b/content/00.zksync-era/50.sdk/40.java/20.guides/01.features.md
@@ -21,7 +21,7 @@ This document will focus solely on how to pass these arguments to the SDK.
 ## Encoding paymaster params
 
 While the paymaster feature by itself does not impose any limitations on values of the `paymasterInput`,
-the Matter Labs team endorses certain types of
+the ZKsync protocol endorses certain types of
 [paymaster flows](/zksync-protocol/account-abstraction/paymasters#built-in-paymaster-flows)
 that are processable by EOAs.
 

--- a/content/20.zksync-protocol/80.account-abstraction/30.paymasters.md
+++ b/content/20.zksync-protocol/80.account-abstraction/30.paymasters.md
@@ -77,7 +77,7 @@ flow). These flows serve mostly as instructions to EOAs and the requirements sho
 ## Testnet paymaster
 
 To ensure users experience paymasters on testnet, as well as keep supporting paying
-fees in ERC20 tokens, the Matter Labs team provides the testnet paymaster, that
+fees in ERC20 tokens, ZKsync chains provide a testnet paymaster, that
 enables paying fees in ERC20 token at a 1:1 exchange rate with ETH (i.e. one unit of this token is equal to 1 wei of ETH).
 
 The paymaster supports only the approval based paymaster flow and requires


### PR DESCRIPTION
# Description

- Documents ZKsync Era testnet paymaster
- Removes ML mentions on protocol features

## Linked Issues

N/A

## Additional context
