### PR TITLE
feat: adds ai links

### DIFF
--- a/components/layout/Toc.vue
+++ b/components/layout/Toc.vue
@@ -10,7 +10,13 @@ const props = defineProps<{
 
 // calculate the current full URL to use in links below
 const route = useRoute();
-const currentUrl = computed(() => `${window.location.origin}${route.fullPath}`);
+const currentUrl = computed(() => {
+  if (import.meta.client) {
+    return `${window.location.origin}${route.fullPath}`;
+  }
+  // Fallback for SSR/CI: just use the path
+  return route.fullPath;
+});
 
 const links = computed(() =>
   [

--- a/components/layout/Toc.vue
+++ b/components/layout/Toc.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
 import type { ParsedContent } from '@nuxt/content/types';
+import { useRoute } from 'vue-router';
 
 const { toc } = useAppConfig();
 
 const props = defineProps<{
   page: ParsedContent;
 }>();
+
+// calculate the current full URL to use in links below
+const route = useRoute();
+const currentUrl = computed(() => `${window.location.origin}${route.fullPath}`);
 
 const links = computed(() =>
   [
@@ -16,9 +21,21 @@ const links = computed(() =>
       target: '_blank',
     },
     {
-      icon: 'i-heroicons-chat-bubble-oval-left-ellipsis',
+      icon: 'i-heroicons-envelope',
       label: 'Share feedback',
       to: `https://github.com/matter-labs/zksync-docs/issues/new?labels=feedback%2Ctriage&projects=&template=feedback.yml&title=%5BFeedback%5D%3A+&page=https://docs.zksync.io${props.page?._path}`,
+      target: '_blank',
+    },
+    {
+      icon: 'i-heroicons-chat-bubble-left-right',
+      label: 'Open in ChatGPT',
+      to: `https://chatgpt.com/?q=Read%20${currentUrl.value}%20and%20all%20its%20subpages%20and%20answer%20questions%20about%20the%20content.`,
+      target: '_blank',
+    },
+    {
+      icon: 'i-heroicons-chat-bubble-bottom-center-text',
+      label: 'Open in Claude',
+      to: `https://claude.ai/new?q=Read%20${currentUrl.value}%20and%20all%20its%20subpages%20and%20answer%20questions%20about%20the%20content.`,
       target: '_blank',
     },
     ...(toc?.bottom?.links || []),


### PR DESCRIPTION
# Description

Add links to ChatGPT and Claude in sidebar as requested in #416 

## Linked Issues

#416 

## Additional context

<img width="512" height="696" alt="CleanShot 2025-07-28 at 10 21 58@2x" src="https://github.com/user-attachments/assets/2cf15958-1d83-4f45-8c5d-90e5ff96ceb9" />
