### PR TITLE
chore: use rich-account command for zkstack

### DIFF
--- a/content/10.zk-stack/20.running/20.using-a-local-zk-chain.md
+++ b/content/10.zk-stack/20.running/20.using-a-local-zk-chain.md
@@ -17,6 +17,12 @@ If you choose to deploy on local [reth](https://ghcr.io/paradigmxyz/reth) node, 
 You can find the list of rich wallets on GitHub in the [matter-labs/local-setup project](https://github.com/matter-labs/local-setup/blob/main/rich-wallets.json)
 and use these addresses to deposit into your ZKsync chain via the bridge.
 
+You can use `zkstack` to bridge ETH from one of these rich wallets to a local chain:
+
+```bash
+zkstack dev rich-account --chain <YOUR_CHAIN_NAME>
+```
+
 ### Base layer is an Ethereum network (e.g., Sepolia)
 
 If you choose to deploy on an Ethereum network (e.g., Sepolia), you need to have an account on the base layer with ETH.

--- a/content/10.zk-stack/35.prividium/_partials/quickstart/_wallet.md
+++ b/content/10.zk-stack/35.prividium/_partials/quickstart/_wallet.md
@@ -12,26 +12,9 @@ You can find a full list of rich wallet addresses and their private keys in the 
 Never use these wallets in production or send real funds to them.
 ::
 
-Open a new terminal and run the command below to bridge some ETH to `prividium_chain` using ZKsync CLI:
+Open a new terminal and run the command below to bridge some ETH to `prividium_chain`.
+This command will bridge 1 ETH to `0x36615cf349d7f6344891b1e7ca7c72883f5dc049`.
 
 ```bash
-npx zksync-cli bridge deposit --rpc=http://localhost:3050 --l1-rpc=http://localhost:8545
+zkstack dev rich-account --chain prividium_chain
 ```
-
-For testing purposes, we'll use one of the rich wallets as both the sender and recipient:
-
-```shell
-? Amount to deposit 10
-? Private key of the sender 0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110
-? Recipient address on L2 0x36615Cf349d7F6344891B1e7CA7C72883F5dc049
-```
-
-To see that it worked, let's check the balance of that address on `prividium_chain`:
-
-```bash
-npx zksync-cli wallet balance \
---address 0x36615Cf349d7F6344891B1e7CA7C72883F5dc049 \
---rpc http://localhost:3050
-```
-
-Now this address has ETH available on `prividium_chain` to use for testing.


### PR DESCRIPTION
- replaces zksync-cli bridge command with zkstack's rich-account command in prividium guide
- adds zkstack's rich-account command to "using a local Zksync chain" page