### PR TITLE
fix: small update to zks_getL2ToL1LogProof

### DIFF
--- a/content/20.zksync-protocol/10.api/40.zks-rpc.md
+++ b/content/20.zksync-protocol/10.api/40.zks-rpc.md
@@ -54,6 +54,8 @@ items: [{
 
 Retrieves the log proof for an L2 to L1 transaction.
 
+Note: The log proof can only be generated after the corresponding L2 transaction has been finalized (executed) on L1.
+
 #### Parameters
 
 1. **DATA, 32 bytes** - transaction hash.
@@ -64,6 +66,7 @@ Retrieves the log proof for an L2 to L1 transaction.
 - **proof**: Array of DATA, 32 bytes - array of strings, each representing a piece of the proof for the specified log.
 - **id**: integer - identifier of the log within the transaction.
 - **root**: DATA, 32 bytes - root hash of the proof, anchoring it to a specific state in the blockchain.
+- **batchNumber**: integer - The number of the batch on L2 where the transaction containing the log was executed.
 
 #### Example Request
 
@@ -97,7 +100,8 @@ items: [{
       "0xac506ecb5465659b3a927143f6d724f91d8d9c4bdb2463aee111d9aa869874db"
     ],
     "id": 0,
-    "root": "0x920c63cb0066a08da45f0a9bf934517141bd72d8e5a51421a94b517bf49a0d39"
+    "root": "0x920c63cb0066a08da45f0a9bf934517141bd72d8e5a51421a94b517bf49a0d39",
+    "batchNumber": 21710
   },
   "id": 1
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the ZKsync Docs!

Before submitting the PR, please make sure you do the following:

- Update your PR title to follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- Read the [Contributing Guide](https://github.com/matter-labs/zksync-docs/blob/main/CONTRIBUTING.md).
- Understand our [Code of Conduct](https://github.com/matter-labs/zksync-docs/blob/main/CODE_OF_CONDUCT.md)
- Please delete any unused parts of the template when submitting your PR

-->

# Description

<!-- Please describe what are the changes and what they are solving for in this PR. -->
- Adds undocumented field `batchNumber` to zks_getL2ToL1LogProof. 

## Linked Issues

<!-- If you have any issues this PR is related to, link them here. -->
<!--
Check out https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
on how to automate linking a GitHub Issue to a PR.
-->

## Additional context
