### PR TITLE
Add ethfaucet.com to network faucets list

### DIFF
--- a/content/00.zksync-network/25.zksync-era/60.ecosystem/60.network-faucets.md
+++ b/content/00.zksync-network/25.zksync-era/60.ecosystem/60.network-faucets.md
@@ -14,6 +14,7 @@ To access the testnet funds (Sepolia) you can use one of the following third par
 | [LearnWeb3](https://learnweb3.io/faucets/zksync_sepolia/)       | 0.01 ETH            | GitHub authentication   |
 | [GetBlock](https://getblock.io/faucet/zksync-sepolia/)          | 0.1 ETH            | GetBlock account        |
 | [Alchemy](https://www.alchemy.com/faucets/zksync-sepolia)       | 0.1 ETH | Alchemy account required       |
+| [ethfaucet.com](https://ethfaucet.com?utm_source=zksync_docs&utm_medium=docs)       | 0.1 ETH | BringID verification      |
 
 ## Sepolia faucets
 
@@ -27,6 +28,7 @@ using the [ZKsync Bridge](https://portal.zksync.io/bridge?network=sepolia).
 - [Infura Sepolia faucet](https://www.infura.io/faucet/sepolia/)
 - [Ethereum Ecosystem Sepolia faucet](https://www.ethereum-ecosystem.com/faucets/ethereum-sepolia)
 - [GetBlock Sepolia faucet](https://getblock.io/faucet/eth-sepolia/)
+- [ethfaucet.com](https://ethfaucet.com?utm_source=zksync_docs&utm_medium=docs)
 
 ## Sepolia USDC faucet
 


### PR DESCRIPTION
# Description

Adding a new faucet (ethfaucet.com) to the docs.
ethfaucet.com provides developers with 0.1 zkSync Era ETH for free, claimable once every 24 hours.

## Additional context

ethfaucet.com is maintained and powered by BringID. BringID is a proof-of-humanity solution from web accounts helping crypto apps to resist sybil attacks and bot abuse.