### PR TITLE
docs: add Codex to data indexers page

### DIFF
--- a/content/00.zksync-network/25.zksync-era/60.ecosystem/30.data-indexers.md
+++ b/content/00.zksync-network/25.zksync-era/60.ecosystem/30.data-indexers.md
@@ -15,6 +15,13 @@ For an extended list of options within the ZKsync ecosystem, feel free to explor
 categories on Dappradar.
 ::
 
+## Codex
+
+[Codex](https://www.codex.io/) is a blockchain data API that provides real-time and historical
+DeFi data across 80+ networks via GraphQL. With access to data on over 70 million tokens and
+700 million wallets, Codex enables developers to build token explorers, trading bots, portfolio
+trackers, and DeFi dashboards with sub-second data delivery through queries, WebSocket subscriptions, and webhooks.
+
 ## DipDup
 
 [DipDup](https://dipdup.io/) is a Python framework for building smart contract indexers. It


### PR DESCRIPTION
Adds Codex to the data indexers ecosystem page as a blockchain data API provider.