### PR TITLE
docs: update warning about private keys in .env

### DIFF
--- a/content/00.zksync-network/10.guides/20.zksync-101/_hello/_era-vm.md
+++ b/content/00.zksync-network/10.guides/20.zksync-101/_hello/_era-vm.md
@@ -87,7 +87,7 @@ rich wallets for transactions and deployments.
 Copy the private key for the first rich wallet from `.env.example` to the `.env` file.
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
-Never save a real private key to the `.env` file!
+Never store a private key associated with real funds in the `.env` file! The `.env` file stores keys in plain text, which is a security risk. Use only test or burner wallets for development.
 ::
 
 ## Deploy the contract

--- a/content/00.zksync-network/10.guides/20.zksync-101/_hello/_evm.md
+++ b/content/00.zksync-network/10.guides/20.zksync-101/_hello/_evm.md
@@ -32,6 +32,10 @@ rich wallets for transactions and deployments.
 
 Copy one of the private keys logged after starting the node to the `.env` file, using the `.env.example` file as an example.
 
+::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
+Never store a private key associated with real funds in the `.env` file! The `.env` file stores keys in plain text, which is a security risk. Use only test or burner wallets for development.
+::
+
 ## Deploy the contract
 
 The deployment script is located at

--- a/content/00.zksync-network/40.tooling/20.hardhat/10.installation.md
+++ b/content/00.zksync-network/40.tooling/20.hardhat/10.installation.md
@@ -88,7 +88,7 @@ zksync-cli create <project-name> --template hardhat_vyper
    ```
 
    ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
-   **Security tip**: Use burner wallets for development and testing to avoid using real private keys, which could lead to security risks.
+   Never store a private key associated with real funds in the `.env` file! The `.env` file stores keys in plain text, which is a security risk. Use only test or burner wallets for development.
    ::
 
 2. **Check configuration**:

--- a/content/00.zksync-network/40.tooling/20.hardhat/20.guides/10.getting-started.md
+++ b/content/00.zksync-network/40.tooling/20.hardhat/20.guides/10.getting-started.md
@@ -102,6 +102,10 @@ WALLET_PRIVATE_KEY=YourPrivateKeyHere
 
 Your private key will be used for paying the costs of deploying the smart contract.
 
+::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
+Never store a private key associated with real funds in the `.env` file! The `.env` file stores keys in plain text, which is a security risk. Use only test or burner wallets for development.
+::
+
 ## Compile and deploy a contract
 
 Smart contracts belong in the `contracts` folder. Both the Solidity and Vyper templates contain a simple `Greeter` contract.


### PR DESCRIPTION
## Summary

Updates and standardizes warnings about storing private keys in `.env` files across the documentation.

Closes #187

## Changes

- **`_era-vm.md`**: Enhanced existing warning to explain *why* `.env` is risky (plain text) and recommend test/burner wallets
- **`_evm.md`**: Added missing warning callout about private keys in `.env`
- **`hardhat/getting-started.md`**: Added warning callout after private key setup instructions
- **`hardhat/installation.md`**: Updated security tip to use consistent, stronger warning language

All warnings now use a consistent message:
> Never store a private key associated with real funds in the `.env` file! The `.env` file stores keys in plain text, which is a security risk. Use only test or burner wallets for development.