### PR TITLE
docs: replace tally links, update upgrades doc

### DIFF
--- a/content/20.zksync-protocol/05.gateway/00.index.md
+++ b/content/20.zksync-protocol/05.gateway/00.index.md
@@ -22,7 +22,7 @@ not from Gateway.
 
 ## Governance
 
-ZKsync Gateway was **whitelisted as a shared proof aggregation layer** in the [ZIP-10 governance proposal](https://www.tally.xyz/gov/zksync/proposal/97689115420129047109255183628089175185608660755000395855946331923921270505453?govId=eip155:324:0x76705327e682F2d96943280D99464Ab61219e34f).
+ZKsync Gateway was **whitelisted as a shared proof aggregation layer** in the [ZIP-10 governance proposal](https://alt.vote.zknation.io/proposal/97689115420129047109255183628089175185608660755000395855946331923921270505453).
 This proposal allows chain operators to select ZKsync Gateway as their proof aggregation middleware instead of submitting proofs directly to Ethereum.
 
 Migration to ZKsync Gateway is **optional**, and chains initially launch with direct Ethereum integration.

--- a/content/20.zksync-protocol/90.upgrades-and-migrations.md
+++ b/content/20.zksync-protocol/90.upgrades-and-migrations.md
@@ -4,11 +4,20 @@ description: Learn about recent upgrades and migrations for ZKsync.
 ---
 
 Learn about recent upgrades, breaking changes, and migrations in the ZKsync ecosystem here.
-For more details, you can check out the ZKsync [governance proposals](https://www.tally.xyz/gov/zksync/proposals),
+For more details, you can check out the ZKsync [governance proposals](https://alt.vote.zknation.io/),
 the [`CHANGELOG.md`](https://github.com/matter-labs/zksync-era/blob/main/core/CHANGELOG.md) and
 [releases](https://github.com/matter-labs/zksync-era/releases) for the `zksync-era` repository.
 
 ## 2025
+
+### November 2025
+
+#### ZK Token Permissionless Burning
+
+- Introduced permissionless burning of the ZK token for any holder.
+- Added a BURNER_ROLE to allow certain addresses to burn tokens from designated accounts.
+- Added a public max supply of 21 billion ZK, enforced by the token contract.
+- Read more details in the official [governance proposal](https://alt.vote.zknation.io/proposal/56697539346434504259886089137844919991955896472242107434527974192173343556352).
 
 ### October 2025
 
@@ -21,7 +30,7 @@ Introduces ZKsync OS with Airbender as the new system for the ZK Stack, which en
 - $0.0001 proving cost per transfer
 
 A ZKsync OS CTM was added to support the Atlas upgrade.
-More details are available in the official [governance proposal](https://www.tally.xyz/gov/zksync/proposal/22471812359223094779541460804735287481991027375586193607912523407322605938475).
+More details are available in the official [governance proposal](https://alt.vote.zknation.io/proposal/22471812359223094779541460804735287481991027375586193607912523407322605938475).
 
 #### Interop Messaging Upgrade
 
@@ -30,7 +39,7 @@ More details are available in the official [governance proposal](https://www.tal
 - Allows block times to be reduced to 200ms.
 - New EVM Interpreter pre deployed contracts:
 [Universal deployer](https://gist.github.com/Agusx1211/de05dabf918d448d315aa018e2572031) and legacy Safe deployers (v1.0.0 to v1.4.1).
-- Read more details in the official [governance proposal](https://www.tally.xyz/gov/zksync/proposal/40562439712311128665286075271414168289029475306445402072499591795343687723101).
+- Read more details in the official [governance proposal](https://alt.vote.zknation.io/proposal/40562439712311128665286075271414168289029475306445402072499591795343687723101).
 
 ### June 2025
 
@@ -39,12 +48,12 @@ More details are available in the official [governance proposal](https://www.tal
 - Introduced version 28.
 - Added more efficient versions of `ecMul`, `ecAdd` and `ecParing` precompiles.
 - New `modexp` precompile.
-- Read more details in the official [governance proposal](https://www.tally.xyz/gov/zksync/proposal/54063168049426383294336598998322383147338444177076559098597792110160570100155).
+- Read more details in the official [governance proposal](https://alt.vote.zknation.io/proposal/54063168049426383294336598998322383147338444177076559098597792110160570100155).
 
 #### Gateway
 
 - Enabled ZKsync Gateway as an optional aggregation layer for ZKsync Chains.
-- Read more details in the official [governance proposal](https://www.tally.xyz/gov/zksync/proposal/97689115420129047109255183628089175185608660755000395855946331923921270505453).
+- Read more details in the official [governance proposal](https://alt.vote.zknation.io/proposal/97689115420129047109255183628089175185608660755000395855946331923921270505453).
 
 ### April 2025
 
@@ -52,7 +61,15 @@ More details are available in the official [governance proposal](https://www.tal
 
 - Introduced version 27.
 - Added support for EVM contracts, enabling standard EVM tooling for ZKsync.
-- Read more details in the official [governance proposal](https://www.tally.xyz/gov/zksync/proposal/112142012854508751423955156601121618924383324119199970784935099214632480260394).
+- Read more details in the official [governance proposal](https://alt.vote.zknation.io/proposal/112142012854508751423955156601121618924383324119199970784935099214632480260394).
+
+### March 2025
+
+#### Chain Creation Parameters Upgrade
+
+- Updated chain creation parameters to ensure consistency for genesis batch data.
+- Fixed default wrapped base token metadata for genesis upgrades.
+- Read more details in the official [governance proposal](https://alt.vote.zknation.io/proposal/98806622840077485421207653857298019081476009136539565020582912190689619102417).
 
 ### February 2025
 
@@ -62,17 +79,29 @@ More details are available in the official [governance proposal](https://www.tal
 - Completed changes necessary to prepare for ZKsync Gateway.
 - Added support for custom DA layers.
 - Updated the bridging architecture.
-- Read more details in the official [governance proposal](https://www.tally.xyz/gov/zksync/proposal/67712324710515983914473127418805437707715095849437613773846173900686148862581).
+- Read more details in the official [governance proposal](https://alt.vote.zknation.io/proposal/67712324710515983914473127418805437707715095849437613773846173900686148862581).
+
+#### Governance Contracts Upgrade
+
+- Reduced the ZIP voting delay from 7 days to 3 days.
+- Reduced the quorum extension from 7 days to 2 days.
+- Redeployed the `ProtocolUpgradeHandler` contract to an upgradable version.
+- Read more details in the official [governance proposal](https://alt.vote.zknation.io/proposal/32477831455745537024214395992964479454779258818502397012096084176779102554510).
 
 ## 2024
 
 ### December 2024
 
+#### Reduce Execution Delay
+
+- Reduced the execution delay from 21 hours to 3 hours.
+- Read more details in the official [governance proposal](https://alt.vote.zknation.io/proposal/26668700835266663714039744560208859829224989416465690918246196287077853242).
+
 #### Protocol Defense Upgrade
 
 - Introduced version 25.
 - Implemented several code quality improvements and gas optimizations.
-- Read more details in the official [governance proposal](https://www.tally.xyz/gov/zksync/proposal/39897055470405054808751466940888279812739313934036970931300785151980460250983).
+- Read more details in the official [governance proposal](https://alt.vote.zknation.io/proposal/65279190639255234983262793933610337632105558452437174222496188099735337695645).
 
 ### September 2024
 


### PR DESCRIPTION
- replaces tally.xyz links with zknation proposal links
- updates the upgrades and migrations page to cover all upgrades [listed](https://alt.vote.zknation.io/?governor=0x76705327e682F2d96943280D99464Ab61219e34f)