### PR TITLE
fix: stop API reference redirect loop

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -177,11 +177,6 @@
         "type": 301
       },
       {
-        "source": "/zksync-protocol/api",
-        "destination": "/build/api-reference",
-        "type": 301
-      },
-      {
         "source": "/build/api-reference",
         "destination": "/zksync-protocol/api",
         "type": 301


### PR DESCRIPTION
## Summary
- remove the redirect from `/zksync-protocol/api` to `/build/api-reference`
- keep the legacy `/build/api-reference` redirect pointed at `/zksync-protocol/api`
- fix the `ERR_TOO_MANY_REDIRECTS` loop reached from Developers -> APIs

## Root Cause
`firebase.json` had two 301 redirects pointing at each other:
- `/zksync-protocol/api` -> `/build/api-reference`
- `/build/api-reference` -> `/zksync-protocol/api`

## Sources
- `firebase.json` (redirects section)
- user report reproducing the live loop: `https://docs.zksync.io/zksync-protocol/api` and `https://docs.zksync.io/build/api-reference`

## Uncertainty List
- none

## Acceptance Criteria
- [x] `/zksync-protocol/api` remains the canonical API docs path
- [x] `/build/api-reference` redirects to `/zksync-protocol/api`
- [x] `bun run ci:check`
- [ ] `bun run build` blocked locally by `[@nuxtjs/algolia] Missing apiKey`

## Policy Check
- no forbidden paths were modified
