### PR TITLE
feat: add BattleChain Mainnet (chainId 626) to ecosystem chains

### DIFF
--- a/data/chains.json
+++ b/data/chains.json
@@ -306,5 +306,16 @@
     "baseToken": "ETH",
     "pubdataMode": "Rollup",
     "dataAvailability": "Ethereum"
+  },
+  {
+    "name": "BattleChain Mainnet",
+    "chainId": 626,
+    "icon": "https://raw.githubusercontent.com/Cyfrin/brand-assets/2d5d104dac174de579de78ea7abb26ccfec9a97c/media/logos/battlechain/color/Battlechain%20Mark%20-%20Color.png",
+    "isTestnet": false,
+    "documentationURL": "https://docs.battlechain.com",
+    "explorerURL": "https://explorer.battlechain.com",
+    "baseToken": "ETH",
+    "pubdataMode": "Rollup",
+    "dataAvailability": "Ethereum"
   }
 ]


### PR DESCRIPTION
Adds BattleChain Mainnet to `data/chains.json`.

BattleChain is Cyfrin's ZKsync-based (ZK Stack) Ethereum L2, mainnet live at chainId 626. It's a rollup with Ethereum data availability — pubdata is posted to L1 as EIP-4844 blobs — so `pubdataMode: Rollup` and `dataAvailability: Ethereum`, matching the profile of other ZK Stack rollups in the list. Native token is ETH.

- Explorer: https://explorer.battlechain.com
- Docs: https://docs.battlechain.com
- Already merged into ethereum-lists/chains: ethereum-lists/chains#8426