### PR TITLE
docs(ecosystem): reference OpenChainBench for live public RPC latency

### DIFF
--- a/content/00.zksync-network/68.zksync-era/60.ecosystem.md
+++ b/content/00.zksync-network/68.zksync-era/60.ecosystem.md
@@ -111,6 +111,7 @@ used in many ZKsync Era workflows.
 - [QuickNode](https://www.quicknode.com/chains/zksync): ZKsync RPC and data
   page.
 - [Unifra](https://unifra.io/): Web3 infrastructure provider used with ZKsync.
+- [OpenChainBench](https://openchainbench.com/benchmarks/zksync-rpc): Live third-party latency comparison of public no-key ZKsync Era RPC endpoints.
 
 ## Paymasters
 


### PR DESCRIPTION
## Summary

Adds one line to the `RPC providers` list in `content/00.zksync-network/68.zksync-era/60.ecosystem.md` pointing at [OpenChainBench — ZKsync Era RPC](https://openchainbench.com/benchmarks/zksync-rpc), a live latency comparison of the public no-key endpoints.

## Why

The list already surfaces third-party services useful to developers picking a ZKsync Era endpoint. OpenChainBench adds a live-data latency dimension, probing the public endpoints from three regions every minute.

- Open methodology: https://openchainbench.com/methodology
- Data license: CC-BY-4.0
- No affiliation with Matter Labs / ZKsync

Happy to drop or reword if this doesn't fit the docs' selective bar.

## Test plan

- [x] Single-line addition matching surrounding bullet style
- [x] External link tested and returns 200