### PR TITLE
docs: add Vultisig to ecosystem wallets

### DIFF
--- a/content/00.zksync-network/68.zksync-era/60.ecosystem.md
+++ b/content/00.zksync-network/68.zksync-era/60.ecosystem.md
@@ -134,5 +134,7 @@ used in many ZKsync Era workflows.
 - [Reown](https://reown.com/?utm_source=zksync&utm_medium=docs&utm_campaign=backlinks):
   Wallet connection and onboarding tooling used by applications that support
   ZKsync Era.
+- [Vultisig](https://vultisig.com): Open-source self-custody wallet with
+  mobile, desktop, and browser extension apps that support ZKsync Era.
 - [Zerion](https://zerion.io/): Wallet and portfolio app that supports ZKsync
   Era.

--- a/cspell-config/cspell-blockchain.txt
+++ b/cspell-config/cspell-blockchain.txt
@@ -53,6 +53,7 @@ validium
 validiums
 viem
 Vitalik
+Vultisig
 vyper
 Weth
 YaspFi


### PR DESCRIPTION
Adds Vultisig to the Wallets section of the ZKsync Era ecosystem page (alphabetical, between Reown and Zerion), plus the `Vultisig` term to `cspell-config/cspell-blockchain.txt` per the contributing guide's spelling-dictionary procedure.

Vultisig is an open-source self-custody wallet (mobile, desktop, browser extension) supporting ZKsync Era — ETH and ERC-20 send/receive/swap. The extension announces via EIP-6963 so it appears in standard wallet pickers.

- Website: https://vultisig.com
- Source: https://github.com/vultisig

## receipts

no runtime changes

Content-only change; ran the repo's own linters locally:
- `markdownlint-cli2` with `.markdownlint.json` → 0 errors
- `cspell` with `cspell.json` → 0 issues (passes because of the dictionary addition)
- prettier: n/a (`**/*.md` is in `.prettierignore`)