### PR TITLE
docs: add Uniblock to the RPC providers list

### DIFF
--- a/content/00.zksync-network/68.zksync-era/60.ecosystem.md
+++ b/content/00.zksync-network/68.zksync-era/60.ecosystem.md
@@ -110,6 +110,9 @@ used in many ZKsync Era workflows.
   access.
 - [QuickNode](https://www.quicknode.com/chains/zksync): ZKsync RPC and data
   page.
+- [Uniblock](https://uniblock.dev/chains/zksync/?utm_source=zksync-docs&utm_medium=ecosystem-docs&utm_campaign=ecosystem&utm_content=intro):
+  Unified JSON-RPC and data API access to ZKsync with automatic failover
+  across 55+ providers.
 - [Unifra](https://unifra.io/): Web3 infrastructure provider used with ZKsync.
 
 ## Paymasters


### PR DESCRIPTION
This PR adds Uniblock to the RPC providers section on the ZKsync Era Ecosystem page.

Uniblock is a unified blockchain API that routes JSON-RPC and data requests for ZKsync across multiple upstream providers. The entry follows this page's existing format.

Disclosure: I work at Uniblock. Happy to adjust wording, formatting, or placement to fit your guidelines.