### PR TITLE
docs: add SwiftNodes to ZKsync Era RPC providers

### DIFF
--- a/content/00.zksync-network/68.zksync-era/60.ecosystem.md
+++ b/content/00.zksync-network/68.zksync-era/60.ecosystem.md
@@ -110,6 +110,7 @@ used in many ZKsync Era workflows.
   access.
 - [QuickNode](https://www.quicknode.com/chains/zksync): ZKsync RPC and data
   page.
+- [SwiftNodes](https://swiftnodes.io/zksync-era-rpc): ZKsync Era RPC over HTTP and WebSocket.
 - [Unifra](https://unifra.io/): Web3 infrastructure provider used with ZKsync.
 
 ## Paymasters


### PR DESCRIPTION
### Summary

Adds **SwiftNodes** to the ZKsync Era RPC providers list.

SwiftNodes is a multi-chain RPC provider offering ZKsync Era Mainnet (chain ID 324) access over HTTP and WebSocket under a single API key, with free and paid plans. Single-line addition inserted alphabetically (between QuickNode and Unifra), matching the existing `- [Name](url): description.` format.
