### PR TITLE
docs: add BoltRPC to ecosystem RPC providers

### DIFF
--- a/content/00.zksync-network/68.zksync-era/60.ecosystem.md
+++ b/content/00.zksync-network/68.zksync-era/60.ecosystem.md
@@ -102,6 +102,7 @@ used in many ZKsync Era workflows.
 - [Alchemy](https://www.alchemy.com/zksync): ZKsync RPC and API page.
 - [Ankr](https://www.ankr.com/rpc/zksync_era/): ZKsync RPC page.
 - [Blockdaemon](https://www.blockdaemon.com/zksync): ZKsync RPC service page.
+- [BoltRPC](https://boltrpc.io/networks/zksync): ZKsync Era RPC endpoints page.
 - [Chainstack](https://chainstack.com/): Infrastructure provider used with
   ZKsync deployments.
 - [dRPC](https://drpc.org/public-endpoints/zksync): ZKsync RPC endpoints page.


### PR DESCRIPTION
## Summary
- Add [BoltRPC](https://boltrpc.io/networks/zksync) to the ZKsync Era ecosystem **RPC providers** list
- Entry matches existing list style and sits alphabetically after Blockdaemon

## Test plan
- [ ] Confirm the RPC providers section renders with the BoltRPC link
- [ ] Confirm https://boltrpc.io/networks/zksync loads and documents ZKsync Era RPC